### PR TITLE
chore: Update ghcr registry path

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,7 +30,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4.4.0
         with:
-          images: ghcr.io/${{ github.repository }}/ebpf-agent
+          images: ghcr.io/honeycombio/ebpf-agent
           tags: dev
 
       - name: Build and push


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the ghcr registry path to only include honeycombio org and not the org plus repository name.