### PR TITLE
chore: Update checkout, login and qemu workflow action versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,17 +11,17 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3.5.3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v2.2.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.9.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,17 +11,17 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3.5.3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v2.2.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.9.0


### PR DESCRIPTION
## Which problem is this PR solving?

Updates checkout, login and qemu workflow action versions to latest.

between this and #12 

current/old:

- actions/checkout@v1
- docker/login-action@v2.1.0
- docker/setup-qemu-action@v2
- docker/setup-buildx-action@v2.5.0
- docker/metadata-action@v4.4.0
- docker/build-push-action@v4.0.0

new:

- actions/checkout@v3.5.3
- docker/login-action@v2.2.0
- docker/setup-qemu-action@v2.2.0
- docker/setup-buildx-action@v2.9.0
- docker/metadata-action@v4.6.0
- docker/build-push-action@v4.1.1