### PR TITLE
maint: Switch to alpine runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /src
 COPY . .
 RUN make build
 
-FROM ubuntu:22.04
-RUN apt-get update -yq && apt-get install -yq ca-certificates
+FROM alpine:3.14
 COPY --from=builder /src/hny-ebpf-agent /bin/hny-ebpf-agent
 CMD [ "/bin/hny-ebpf-agent" ]


### PR DESCRIPTION
## Which problem is this PR solving?

- Switches the runtime image from ubuntu to alpine, reducing image size from ~120mb to 14mb!

I've tested this can continue to send telemetry from local deployment to Honeycomb.