### PR TITLE
ci: fix dev tag on merge to main branch

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,13 +31,16 @@ jobs:
         uses: docker/metadata-action@v4.6.0
         with:
           images: ghcr.io/honeycombio/ebpf-agent
+          tags: |
+            # use dev tag for main branch builds
+            type=raw,value=dev
 
       - name: Build and push
         uses: docker/build-push-action@v4.1.1
         with:
           context: .
           push: true
-          tags: dev
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha


### PR DESCRIPTION
## Which problem is this PR solving?

- Failed [dev image build](https://github.com/honeycombio/honeycomb-ebpf-agent/actions/runs/5535832187/jobs/10102667363) on last merge to main

## Short description of the changes

- Add dev tag back to metadata-action step (otherwise it defaults to main as `ghcr.io/honeycombio/ebpf-agent:main` instead of `ghcr.io/honeycombio/ebpf-agent:dev`), along with note that indicates its purpose and [type](https://github.com/marketplace/actions/docker-metadata-action#typeraw)
- Update Build and push to use the tag from the metadata-action step because that ensures it has the full name of the image for ghcr.
  - Failed step shows `#32 [auth] library/dev:pull,push token for registry-1.docker.io`
  - Successful step shows `#25 [auth] honeycombio/ebpf-agent:pull,push token for ghcr.io`
- See details of [last successful build](https://github.com/honeycombio/honeycomb-ebpf-agent/actions/runs/5524876451/jobs/10077777697) on main.
- See details of [last failed build](https://github.com/honeycombio/honeycomb-ebpf-agent/actions/runs/5535832187/jobs/10102667363) on main.

## How to verify that this has the expected result

Next merge to main should properly build and push a dev tag.