### PR TITLE
maint: Update create Github Release job to have write contents access

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,6 @@ jobs:
   build-and-publish-docker-image:
     runs-on: ubuntu-22.04
     permissions:
-      contents: read
       packages: write
     steps:
       - uses: actions/checkout@v3.5.3
@@ -43,8 +42,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Release
+  github-release:
+    needs: build-and-publish-docker-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create Github Release
         uses: softprops/action-gh-release@v1
         with:
           prerelease: true
           draft: true
+          generate_release_notes: true


### PR DESCRIPTION
## Which problem is this PR solving?
The create Github release job in the release workflow failed because it needs write access for contents.

## Short description of the changes
- Separate gituhb release docker image build & push from github release job
- Give github release job `contents: write` permission
- Add `generate_release_notes` option to automatically generate release notes in github release
- Remove unnecessary `contents: read` permission from docker build and publish job -- workflows always have contents read access

## How to verify that this has the expected result
