### PR TITLE
maint: Don’t set priviledged mode by default in deployment.yaml

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -95,5 +95,7 @@ spec:
                 - BPF
                 - PERFMON
                 - NET_RAW
+            # for local debugging
+            # privileged: true
       imagePullSecrets:
         - name: ghcr


### PR DESCRIPTION
## Which problem is this PR solving?
The agent does not to run in privileded mode so we comment it out so it's findable but on by default.

- Close #64 

## Short description of the changes
- Comment out the `priviledged` option from deploymeny.yaml

## How to verify that this has the expected result
Agent continues to run as normal.