### PR TITLE
fix: time units in telemetry

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,9 +16,10 @@ import (
 	"github.com/honeycombio/libhoney-go"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
 )
 
 const Version string = "0.0.3-alpha"
@@ -136,9 +137,9 @@ func sendHttpEventToHoneycomb(event assemblers.HttpEvent, k8sClient *utils.Cache
 	// common attributes
 	ev.Timestamp = event.Timestamp
 	ev.AddField("httpEvent_handled_at", time.Now())
-	ev.AddField("httpEvent_handled_latency", time.Now().Sub(event.Timestamp))
+	ev.AddField("httpEvent_handled_latency_ms", time.Now().Sub(event.Timestamp).Milliseconds())
 	ev.AddField("goroutine_count", runtime.NumGoroutine())
-	ev.AddField("duration_ms", event.Duration.Microseconds())
+	ev.AddField("duration_ms", event.Duration.Milliseconds())
 	ev.AddField(string(semconv.NetSockHostAddrKey), event.SrcIp)
 	ev.AddField("destination.address", event.DstIp)
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Closes #92 

## Short description of the changes

- use explicit time units in telemetry name
- use ms for time data

## How to verify that this has the expected result

- build & run
- explore latency and duration telemetry
