### PR TITLE
maint: Readd contents read permission to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ jobs:
   build-and-publish-docker-image:
     runs-on: ubuntu-22.04
     permissions:
+      contents: read
       packages: write
     steps:
       - uses: actions/checkout@v3.5.3


### PR DESCRIPTION
## Which problem is this PR solving?

Release workflow fails because it can't read the repository contents. This was removed in a previous commit.

## Short description of the changes
- Re-add contents read permission for docker build push job