### PR TITLE
maint: Move stream flushing to ticker

### DIFF
--- a/assemblers/tcp_assembler.go
+++ b/assemblers/tcp_assembler.go
@@ -105,78 +105,75 @@ func NewTcpAssembler(config config, httpEvents chan HttpEvent) tcpAssembler {
 }
 
 func (h *tcpAssembler) Start() {
-
-	// start up http event handler
-
+	log.Info().Msg("Starting TCP assembler")
+	flushTicker := time.NewTicker(time.Second * 5)
 	count := 0
 	bytes := int64(0)
 	start := time.Now()
 	defragger := ip4defrag.NewIPv4Defragmenter()
-	for packet := range h.packetSource.Packets() {
-		count++
-		data := packet.Data()
-		bytes += int64(len(data))
-		// defrag the IPv4 packet if required
-		if !h.config.Nodefrag {
-			ip4Layer := packet.Layer(layers.LayerTypeIPv4)
-			if ip4Layer == nil {
-				continue
-			}
-			ip4 := ip4Layer.(*layers.IPv4)
-			l := ip4.Length
-			newip4, err := defragger.DefragIPv4(ip4)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Error while de-fragmenting")
-			} else if newip4 == nil {
-				log.Debug().Msg("Fragment...\n")
-				continue // packet fragment, we don't have whole packet yet.
-			}
-			if newip4.Length != l {
-				stats.ipdefrag++
-				log.Debug().
-					Str("network_layer_type", newip4.NextLayerType().String()).
-					Msg("Decoding re-assembled packet")
-				pb, ok := packet.(gopacket.PacketBuilder)
-				if !ok {
-					panic("Not a PacketBuilder")
-				}
-				nextDecoder := newip4.NextLayerType()
-				nextDecoder.Decode(newip4.Payload, pb)
-			}
-		}
 
-		tcp := packet.Layer(layers.LayerTypeTCP)
-		if tcp != nil {
-			tcp := tcp.(*layers.TCP)
-			if h.config.Checksum {
-				err := tcp.SetNetworkLayerForChecksum(packet.NetworkLayer())
-				if err != nil {
-					log.Fatal().Err(err).Msg("Failed to set network layer for checksum")
-				}
-			}
-			c := Context{
-				CaptureInfo: packet.Metadata().CaptureInfo,
-			}
-			stats.totalsz += len(tcp.Payload)
-			h.assembler.AssembleWithContext(packet.NetworkLayer().NetworkFlow(), tcp, &c)
-		}
-		if count%h.config.Statsevery == 0 {
-			ref := packet.Metadata().CaptureInfo.Timestamp
+	for {
+		select {
+		case <-flushTicker.C:
 			flushed, closed := h.assembler.FlushCloseOlderThan(time.Now().Add(-h.config.Timeout))
 			log.Debug().
 				Int("flushed", flushed).
 				Int("closed", closed).
-				Time("packet_timestamp", ref).
-				Msg("Forced flush")
-		}
+				Msg("Flushing old streams")
+		case packet := <-h.packetSource.Packets():
+			count++
+			data := packet.Data()
+			bytes += int64(len(data))
+			// defrag the IPv4 packet if required
+			if ipv4Layer := packet.Layer(layers.LayerTypeIPv4); ipv4Layer != nil {
+				ipv4 := ipv4Layer.(*layers.IPv4)
+				newipv4, err := defragger.DefragIPv4(ipv4)
+				if err != nil {
+					log.Debug().Err(err).Msg("Error while de-fragmenting")
+					continue
+				}
+				if newipv4 == nil {
+					log.Debug().Msg("Ingoring packet fragment")
+					continue
+				}
 
-		done := h.config.Maxcount > 0 && count >= h.config.Maxcount
-		if count%h.config.Statsevery == 0 || done {
-			log.Debug().
-				Int("processed_count_since_start", count).
-				Int64("milliseconds_since_start", time.Since(start).Milliseconds()).
-				Int64("bytes", bytes).
-				Msg("Processed Packets")
+				// decode the packet if required
+				if newipv4.Length != ipv4.Length {
+					stats.ipdefrag++
+					builder, ok := packet.(gopacket.PacketBuilder)
+					if !ok {
+						log.Debug().Msg("Unable to decode packet - does not contain PacketBuilder")
+					}
+					nextDecoder := newipv4.NextLayerType()
+					nextDecoder.Decode(newipv4.Payload, builder)
+				}
+			}
+
+			// process TCP packet
+			if tcpLayer := packet.Layer(layers.LayerTypeTCP); tcpLayer != nil {
+				tcp := tcpLayer.(*layers.TCP)
+				if h.config.Checksum {
+					err := tcp.SetNetworkLayerForChecksum(packet.NetworkLayer())
+					if err != nil {
+						log.Debug().Err(err).Msg("Failed to set network layer for checksum")
+						continue
+					}
+				}
+				context := Context{
+					CaptureInfo: packet.Metadata().CaptureInfo,
+				}
+				stats.totalsz += len(tcp.Payload)
+				h.assembler.AssembleWithContext(packet.NetworkLayer().NetworkFlow(), tcp, &context)
+			}
+
+			done := h.config.Maxcount > 0 && count >= h.config.Maxcount
+			if count%h.config.Statsevery == 0 || done {
+				log.Debug().
+					Int("processed_count_since_start", count).
+					Int64("milliseconds_since_start", time.Since(start).Milliseconds()).
+					Int64("bytes", bytes).
+					Msg("Processed Packets")
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?
We currently flush old streams as part of packet processing when a certain number of packets have been processed. This PR moves the flush process to a separate process using a ticker interval.

- Closes #99 

## Short description of the changes
- Add new flush ticker
- Update for select to switch over each ticker and packet channel
- Remove flush processing from packet processing

## How to verify that this has the expected result
Agent should continue to run as it is - this is a maintenance improvement.