### PR TITLE
maint: Don't deploy kprobes for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ docker-generate:
 	docker run --rm -v $(shell pwd):/src hny/ebpf-agent-builder
 
 .PHONY: build
-build: generate
+build:
 	CGO_ENABLED=1 GOOS=linux go build -o hny-ebpf-agent main.go
 
 .PHONY: docker-build

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/honeycombio/ebpf-agent/assemblers"
-	"github.com/honeycombio/ebpf-agent/bpf/probes"
 	"github.com/honeycombio/ebpf-agent/utils"
 	"github.com/honeycombio/libhoney-go"
 	"github.com/rs/zerolog"
@@ -91,11 +90,6 @@ func main() {
 	defer done()
 	cachedK8sClient := utils.NewCachedK8sClient(k8sClient)
 	cachedK8sClient.Start(ctx)
-
-	// setup probes
-	p := probes.New(cachedK8sClient)
-	go p.Start()
-	defer p.Stop()
 
 	agentConfig := assemblers.NewConfig()
 


### PR DESCRIPTION
## Which problem is this PR solving?
We're not currently using the data that comes out of kprobes so we should disable for now.

## Short description of the changes
- Don't call `generate` as part of the `build` makefile target
- Don't setup probes during main.go setup

## How to verify that this has the expected result
No change - we're not using data from the kprobes now.