### PR TITLE
fix: prevent debug log panic

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -87,6 +87,9 @@ spec:
                   key: api-key
             - name: HONEYCOMB_DATASET
               value: ebpf-agent-go
+            ## uncomment this to enable debug logs
+            # - name: DEBUG
+            #   value: "true"
           args:
             - tcp
           securityContext:


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #107

## Short description of the changes
- Check that `event.Request.RequestURI` exists before passing it to the debug log
- Add `DEBUG` environment variable in `deployment.yaml`

## How to verify that this has the expected result
- Enable `DEBUG` through the `deployment.yaml` file
- Run the agent in a k8s cluster
- Should not see a panic error
