### PR TITLE
fix: remove fields for http body and headers

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,8 +148,6 @@ func sendHttpEventToHoneycomb(event assemblers.HttpEvent, k8sClient *utils.Cache
 		ev.AddField("name", fmt.Sprintf("HTTP %s", event.Request.Method))
 		ev.AddField(string(semconv.HTTPMethodKey), event.Request.Method)
 		ev.AddField(string(semconv.HTTPURLKey), requestURI)
-		ev.AddField("http.request.body", fmt.Sprintf("%v", event.Request.Body))
-		ev.AddField("http.request.headers", fmt.Sprintf("%v", event.Request.Header))
 		ev.AddField(string(semconv.UserAgentOriginalKey), event.Request.Header.Get("User-Agent"))
 		ev.AddField("http.request.body.size", bodySize)
 	} else {
@@ -163,8 +161,6 @@ func sendHttpEventToHoneycomb(event assemblers.HttpEvent, k8sClient *utils.Cache
 		bodySize, _ := strconv.ParseInt(bodySizeString, 10, 64)
 
 		ev.AddField(string(semconv.HTTPStatusCodeKey), event.Response.StatusCode)
-		ev.AddField("http.response.body", event.Response.Body)
-		ev.AddField("http.response.headers", event.Response.Header)
 		ev.AddField("http.response.body.size", bodySize)
 
 	} else {


### PR DESCRIPTION
## Which problem is this PR solving?

Disable recording of http body and header. We can consider config options to allow users to opt-in if they choose to enable it... and/or otherwise just be more granular about the specific data that seems relevant.

updates (/closes?) #112 

## Short description of the changes

remove fields from telemetry:
- `http.request.body`
- `http.request.headers`
- `http.response.body`
- `http.response.headers`

## How to verify that this has the expected result

We still get other fields we've specified like `http.request.body.size` based on the `"Content-Length"` header. But we no longer just grab the entire header/body.