### PR TITLE
fix: Remove map entry after finding match

### DIFF
--- a/assemblers/http_matcher.go
+++ b/assemblers/http_matcher.go
@@ -32,6 +32,7 @@ func (m *httpMatcher) GetOrStoreRequest(ident string, timestamp time.Time, reque
 	if e, ok := m.messages[ident]; ok {
 		e.request = request
 		e.requestTimestamp = timestamp
+		delete(m.messages, ident)
 		return &e, true
 	}
 
@@ -52,6 +53,7 @@ func (m *httpMatcher) GetOrStoreResponse(ident string, timestamp time.Time, resp
 	if e, ok := m.messages[ident]; ok {
 		e.response = response
 		e.responseTimestamp = timestamp
+		delete(m.messages, ident)
 		return &e, true
 	}
 


### PR DESCRIPTION
## Which problem is this PR solving?

After updating the http matcher to use a normal map in #117, we didn't remove entry keys from the map which caused it to continually grow.

## Short description of the changes
- Delete entries from the map after finding a match

## How to verify that this has the expected result
Memory consumption will be more consistent as the map does not hold items forever.