### PR TITLE
maint: have dependabot group k8s dependency updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
     commit-message:
       prefix: "maint"
       include: "scope"
+    groups:
+      k8s-dependencies:
+        patterns:
+          - "k8s.io/*"


### PR DESCRIPTION
## Which problem is this PR solving?

- Group related dependency updates together into one PR so they don't get weird moving independently.