### PR TITLE
maint: Remove duplicate assembler stats logging

### DIFF
--- a/assemblers/tcp_assembler.go
+++ b/assemblers/tcp_assembler.go
@@ -162,15 +162,6 @@ func (h *tcpAssembler) Start() {
 				stats.totalsz += len(tcp.Payload)
 				h.assembler.AssembleWithContext(packet.NetworkLayer().NetworkFlow(), tcp, &context)
 			}
-
-			done := h.config.Maxcount > 0 && count >= h.config.Maxcount
-			if count%h.config.Statsevery == 0 || done {
-				log.Debug().
-					Int("processed_count_since_start", count).
-					Int64("milliseconds_since_start", time.Since(start).Milliseconds()).
-					Int64("bytes", bytes).
-					Msg("Processed Packets")
-			}
 		}
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?
We have a duplicate log of stats logging in the assembler in both the new stats ticker and the bottom of the handle packet case.

## Short description of the changes
- Removes duplicate logging from the handle packet case