### PR TITLE
feat: Record total and active stream counts

### DIFF
--- a/assemblers/tcp_assembler.go
+++ b/assemblers/tcp_assembler.go
@@ -2,6 +2,7 @@ package assemblers
 
 import (
 	"runtime"
+	"sync/atomic"
 	"time"
 
 	"github.com/honeycombio/ebpf-agent/config"
@@ -36,6 +37,18 @@ var stats struct {
 	source_if_dropped   int
 	total_streams       uint64
 	active_streams      int64
+}
+
+func IncrementStreamCount() uint64 {
+	return atomic.AddUint64(&stats.total_streams, 1)
+}
+
+func IncrementActiveStreamCount() {
+	atomic.AddInt64(&stats.active_streams, 1)
+}
+
+func DecrementActiveStreamCount() {
+	atomic.AddInt64(&stats.active_streams, -1)
 }
 
 type Context struct {

--- a/assemblers/tcp_stream.go
+++ b/assemblers/tcp_stream.go
@@ -3,7 +3,6 @@ package assemblers
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/honeycombio/ebpf-agent/config"
 	"github.com/honeycombio/gopacket"
@@ -164,7 +163,7 @@ func (t *tcpStream) ReassemblyComplete(ac reassembly.AssemblerContext) bool {
 	t.close()
 
 	// decrement the number of active streams
-	atomic.AddInt64(&stats.active_streams, -1)
+	DecrementActiveStreamCount()
 	return true // remove the connection, heck with the last ACK
 }
 

--- a/assemblers/tcp_stream_factory.go
+++ b/assemblers/tcp_stream_factory.go
@@ -3,7 +3,6 @@ package assemblers
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/honeycombio/ebpf-agent/config"
 	"github.com/honeycombio/gopacket"
@@ -35,7 +34,7 @@ func (factory *tcpStreamFactory) New(net, transport gopacket.Flow, tcp *layers.T
 	}
 
 	// increment total stream count and use as stream id
-	streamId := atomic.AddUint64(&stats.total_streams, 1)
+	streamId := IncrementStreamCount()
 	stream := &tcpStream{
 		config:     factory.config,
 		id:         streamId,
@@ -71,7 +70,7 @@ func (factory *tcpStreamFactory) New(net, transport gopacket.Flow, tcp *layers.T
 	go stream.server.run(&factory.wg)
 
 	// increment the number of active streams
-	atomic.AddInt64(&stats.active_streams, 1)
+	IncrementActiveStreamCount()
 	return stream
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
The agent assigns stream IDs to new streams to help identify them. However, we do not track the total number of streams created or the number of active streams. Streams are considered active once created and while receiving data, when data stops flowing they become eligible for closing.

Understanding the impact of total and active streams is important because we believe this is directly related to memory utilisation and growth.

The PR records the number of active streams and adds both the total and active stream counts to logged stats.

## Short description of the changes
- Move streamID count from stream factory to stats struct as total_streams - this is incremented whenever a new stream is created by the stream factory
- Add active_streams count to stats struct and increment / decrement as new streams are created and closed
- Add both total_streams and active_streams counts to stats fields that are both sent in stats events sent to honeycomb and logged at debug level

## How to verify that this has the expected result
Total and active stream counts are visible in logs and in honeycomb agent stats events.

<img width="1320" alt="image" src="https://github.com/honeycombio/honeycomb-network-agent/assets/3481731/f1743bef-45b6-412d-81c8-64c111077f61">
