### PR TITLE
ci: inject a version at build time based on tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,14 @@ ifeq (,$(wildcard /sys/kernel/btf/vmlinux))
 	BPF_HEADERS += -DBPF_NO_PRESERVE_ACCESS_INDEX
 endif
 
+RELEASE_VERSION ?= $(shell git describe --always --match "v[0-9]*")
 IMG_NAME ?= hny/network-agent
 IMG_TAG ?= local
+
+.PHONY: version
+#: display the current computed project version
+version:
+	@echo $(RELEASE_VERSION)
 
 .PHONY: generate
 generate: export CFLAGS := $(BPF_HEADERS)
@@ -30,7 +36,10 @@ docker-generate:
 .PHONY: build
 #: compile the agent executable
 build:
-	CGO_ENABLED=1 GOOS=linux go build -o hny-network-agent main.go
+	CGO_ENABLED=1 GOOS=linux \
+		go build \
+			--ldflags "-X main.Version=$(RELEASE_VERSION)" \
+			-o hny-network-agent main.go
 
 .PHONY: docker-build
 #: build the agent image

--- a/main.go
+++ b/main.go
@@ -23,7 +23,8 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
 )
 
-const Version string = "0.0.13-alpha"
+var Version string = "dev"
+
 const defaultDataset = "hny-network-agent"
 const defaultEndpoint = "https://api.honeycomb.io"
 


### PR DESCRIPTION
Compute a build version number based on our version tagging scheme. We do this for several other projects.  

```bash
❯ remake version
v0.0.13-alpha-3-g4436c14
```

So a build right now would be based on commit ID 4436c14 which is 3 ahead of v0.0.13-alpha.

We cannot include `--dirty` in the `git describe` command because `.dockerignore` omits some version-controlled files from the docker build environment. That causes git to consider the working copy dirty. An option to help distinguish between the telemetry or profiling output generated by different iterations of work-in-progress is to commit changes before a local build and tag that commit with a meaningful temporary name. For example:

```bash
git tag -a v0.0.13-alpha-moved-conn-creation -m "moved creating connection to the end of the function"
```

This tag would then appear in the version field of emitted telemetry and as a tag in profiling data.

**Also, don't push these tags!**

### A Dev Build

```
❯ remake docker-build
```

Agent log output:

```json
{ "agent_version":"v0.0.13-alpha-3-g4436c14",
  "message":"Starting Honeycomb Network agent" }
```

### A Release Build

Tag that commit. It MUST be an annotated tag for git describe to match against it.

```bash
❯ git tag -a v0.0.13-test-version-inject -m "v0.0.13-test-version-inject"
```

Agent log output:

```json
{ "agent_version":"v0.0.13-test-version-inject",
  "message":"Starting Honeycomb Network agent" }
```