### PR TITLE
maint: Use debug instead of info for HTTP parse errors

### DIFF
--- a/assemblers/tcp_reader.go
+++ b/assemblers/tcp_reader.go
@@ -56,7 +56,7 @@ func (reader *tcpReader) reassembledSG(sg reassembly.ScatterGather, ac reassembl
 		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			return
 		} else if err != nil {
-			log.Info().
+			log.Debug().
 				Err(err).
 				Str("ident", reader.streamIdent).
 				Msg("Error reading HTTP request")
@@ -75,7 +75,7 @@ func (reader *tcpReader) reassembledSG(sg reassembly.ScatterGather, ac reassembl
 		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			return
 		} else if err != nil {
-			log.Info().
+			log.Debug().
 				Err(err).
 				Str("ident", resIdent).
 				Msg("Error reading HTTP response")


### PR DESCRIPTION
## Which problem is this PR solving?
Updates failed HTTP request / response parsing logs to use debug level instead of info.

## Short description of the changes
- Use debug log level for HTTP request / response parse errors

## How to verify that this has the expected result
HTTP parse errors are at debug level instead of info.