### PR TITLE
fix: Close HTTP request & response body readers

### DIFF
--- a/assemblers/tcp_reader.go
+++ b/assemblers/tcp_reader.go
@@ -62,6 +62,11 @@ func (reader *tcpReader) reassembledSG(sg reassembly.ScatterGather, ac reassembl
 				Msg("Error reading HTTP request")
 			return
 		}
+		// We don't need the body, so just close it if set
+		if req.Body != nil {
+			req.Body.Close()
+		}
+
 		if entry, ok := reader.matcher.GetOrStoreRequest(reqIdent, ctx.CaptureInfo.Timestamp, req); ok {
 			// we have a match, process complete request/response pair
 			reader.processEvent(reqIdent, entry)
@@ -81,6 +86,11 @@ func (reader *tcpReader) reassembledSG(sg reassembly.ScatterGather, ac reassembl
 				Msg("Error reading HTTP response")
 			return
 		}
+		// We don't need the body, so just close it if set
+		if res.Body != nil {
+			res.Body.Close()
+		}
+
 		if entry, ok := reader.matcher.GetOrStoreResponse(resIdent, ctx.CaptureInfo.Timestamp, res); ok {
 			// we have a match, process complete request/response pair
 			reader.processEvent(resIdent, entry)


### PR DESCRIPTION
## Which problem is this PR solving?
We are not closing parsed HTTP request or response correctly. We don't use them but not closing the reader correctly can lead to memory leaks as the underlying byte buffer is not released and garbage collected.

## Short description of the changes
- Close both HTTP request and response body readers

## How to verify that this has the expected result
No functional changes as we're not using the HTTP request or response bodies. This should help reduce the amount of memory creep from byte[]'s that are not cleaned up correctly.