### PR TITLE
fix: Reuse buffer in stream reader

### DIFF
--- a/assemblers/tcp_reader.go
+++ b/assemblers/tcp_reader.go
@@ -48,7 +48,7 @@ func (reader *tcpReader) reassembledSG(sg reassembly.ScatterGather, ac reassembl
 	}
 
 	// reset the buffer reader to use the new packet data
-	// bufio.NewReader creates a new 4mb buffer on each call which we want to avoid
+	// bufio.NewReader creates a new 16 byte buffer on each call which we want to avoid
 	// https://github.com/golang/go/blob/master/src/bufio/bufio.go#L57
 	reader.buffer.Reset(bytes.NewReader(data))
 	if reader.isClient {


### PR DESCRIPTION
## Which problem is this PR solving?
After further investigation using profiling, we still see high in-use objects in memory that creep up over an extended time. It looks like each call to [bufio.NewReader](https://github.com/golang/go/blob/master/src/bufio/bufio.go#L57) allocates a new 4mb byte[] which is never cleaned up correctly.

<img width="1623" alt="image" src="https://github.com/honeycombio/honeycomb-network-agent/assets/3481731/e32dbdcf-ebc0-4975-827b-bcbca04f4ce4">

This PR moves the bufio.Reader to the the reader struct and reuses it when processing packet data.

## Short description of the changes
- Add bufio.Reader to tcpReader and initalise during `NewTcpReader`
- Reuse the buffered reader when processing new packet data by calling `Reset` with the new data.

**Note**: We do not cache the io.Reader as this doesn't hold onto the underlying []byte and is cleaned up as expected. See the image above for `bytes.NewReader`.

## How to verify that this has the expected result
Memory consumption over an extended period is more stable and does not incrementally creep up.