### PR TITLE
fix: agent version used in build so gha properly evaluates env var

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,10 +18,16 @@ jobs:
         with:
           buildkitd-flags: --debug
 
+      - name: Determine build release version
+        id: get_version
+        run: echo "RELEASE_VERSION=$(make version)" >> "$GITHUB_ENV"
+
       - name: Build docker image
         uses: docker/build-push-action@v4.1.1
         with:
           context: .
+          build-args: |
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
           push: false
           platforms: linux/amd64
           # platforms: linux/amd64,linux/arm64 - don't build arm64 on PRs for now

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,8 +15,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.9.0
-        with:
-          buildkitd-flags: --debug
 
       - name: Determine build release version
         id: get_version

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,9 +21,10 @@ jobs:
       - name: Determine build release version
         id: get_version
         run: |
-          echo "RELEASE_VERSION is currently: $(RELEASE_VERSION)"
-          echo "I'm going to set it to: $(make version)"
-          echo "RELEASE_VERSION=$(make version)" >> "$GITHUB_ENV"
+          echo "RELEASE_VERSION is currently: ${RELEASE_VERSION}"
+          version=$(git describe --always --match "v[0-9]*")
+          echo "I'm going to set it to: ${version}"
+          echo "RELEASE_VERSION=${version}" >> "$GITHUB_ENV"
 
       - name: Build docker image
         uses: docker/build-push-action@v4.1.1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.9.0
+        with:
+          buildkitd-flags: --debug
 
       - name: Build docker image
         uses: docker/build-push-action@v4.1.1
@@ -23,5 +25,4 @@ jobs:
           push: false
           platforms: linux/amd64
           # platforms: linux/amd64,linux/arm64 - don't build arm64 on PRs for now
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: Determine build release version
         id: get_version
         run: |
+          git fetch --tags
           echo "RELEASE_VERSION is currently: ${RELEASE_VERSION}"
           version=$(git describe --always --match "v[0-9]*")
           echo "I'm going to set it to: ${version}"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,7 +20,10 @@ jobs:
 
       - name: Determine build release version
         id: get_version
-        run: echo "RELEASE_VERSION=$(make version)" >> "$GITHUB_ENV"
+        run: |
+          echo "RELEASE_VERSION is currently: $(RELEASE_VERSION)"
+          echo "I'm going to set it to: $(make version)"
+          echo "RELEASE_VERSION=$(make version)" >> "$GITHUB_ENV"
 
       - name: Build docker image
         uses: docker/build-push-action@v4.1.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Determine build release version
         id: get_version
-        run: echo "RELEASE_VERSION::$(make version)" >> "$GITHUB_ENV"
+        run: echo "RELEASE_VERSION=$(make version)" >> "$GITHUB_ENV"
 
       - name: Build and push
         uses: docker/build-push-action@v4.1.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,9 +36,6 @@ jobs:
         id: get_version
         run: echo "RELEASE_VERSION=$(make version)" >> "$GITHUB_ENV"
 
-      - name: Show the version to be built
-        run: echo $RELEASE_VERSION
-
       - name: Build and push
         uses: docker/build-push-action@v4.1.1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,11 +32,17 @@ jobs:
         with:
           images: ghcr.io/honeycombio/network-agent
 
+      - name: Determine build release version
+        id: get_version
+        run: echo "RELEASE_VERSION::$(make version)" >> "$GITHUB_ENV"
+
       - name: Build and push
         uses: docker/build-push-action@v4.1.1
         with:
           context: .
           push: true
+          build-args: |
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,9 @@ jobs:
         id: get_version
         run: echo "RELEASE_VERSION=$(make version)" >> "$GITHUB_ENV"
 
+      - name: Show the version to be built
+        run: echo $RELEASE_VERSION
+
       - name: Build and push
         uses: docker/build-push-action@v4.1.1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /src
 COPY go.* .
 RUN go mod download
 COPY . .
-RUN make version
+ARG RELEASE_VERSION
 RUN make build
 
 FROM ubuntu:22.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /src
 COPY go.* .
 RUN go mod download
 COPY . .
+RUN make version
 RUN make build
 
 FROM ubuntu:22.04

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,14 @@ ifeq (,$(wildcard /sys/kernel/btf/vmlinux))
 	BPF_HEADERS += -DBPF_NO_PRESERVE_ACCESS_INDEX
 endif
 
-I_MADE_THIS_UP ?= $(shell git describe --always --match "v[0-9]*")
+RELEASE_VERSION ?= $(shell git describe --always --match "v[0-9]*")
 IMG_NAME ?= hny/network-agent
 IMG_TAG ?= local
 
 .PHONY: version
 #: display the current computed project version
 version:
-	@echo $(I_MADE_THIS_UP)
+	@echo $(RELEASE_VERSION)
 
 .PHONY: generate
 generate: export CFLAGS := $(BPF_HEADERS)
@@ -38,13 +38,13 @@ docker-generate:
 build:
 	CGO_ENABLED=1 GOOS=linux \
 		go build \
-			--ldflags "-X main.Version=$(I_MADE_THIS_UP)" \
+			--ldflags "-X main.Version=$(RELEASE_VERSION)" \
 			-o hny-network-agent main.go
 
 .PHONY: docker-build
 #: build the agent image
 docker-build:
-	docker build --tag $(IMG_NAME):$(IMG_TAG) .
+	docker build --tag $(IMG_NAME):$(IMG_TAG) --build-arg="RELEASE_VERSION=$(RELEASE_VERSION)" .
 
 .PHONY: update-headers
 #: retrieve libbpf headers

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ ifeq (,$(wildcard /sys/kernel/btf/vmlinux))
 	BPF_HEADERS += -DBPF_NO_PRESERVE_ACCESS_INDEX
 endif
 
-I_MADE_THIS_UP ?= $(shell git describe --always --match "v[0-9]*")
+# I_MADE_THIS_UP ?= $(shell git describe --always --match "v[0-9]*")
+I_MADE_THIS_UP ?= v0.0.14-alpha-8-g57c7eb0
 IMG_NAME ?= hny/network-agent
 IMG_TAG ?= local
 
@@ -38,7 +39,7 @@ docker-generate:
 build:
 	CGO_ENABLED=1 GOOS=linux \
 		go build \
-			--ldflags "-X main.Version=$(I_MADE_THIS_UP)" \
+			--ldflags "-X main.Version=v0.0.14-alpha-8-g57c7eb0" \
 			-o hny-network-agent main.go
 
 .PHONY: docker-build

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,14 @@ ifeq (,$(wildcard /sys/kernel/btf/vmlinux))
 	BPF_HEADERS += -DBPF_NO_PRESERVE_ACCESS_INDEX
 endif
 
-RELEASE_VERSION ?= $(shell git describe --always --match "v[0-9]*")
+REL_VERSION ?= $(shell git describe --always --match "v[0-9]*")
 IMG_NAME ?= hny/network-agent
 IMG_TAG ?= local
 
 .PHONY: version
 #: display the current computed project version
 version:
-	@echo $(RELEASE_VERSION)
+	@echo $(REL_VERSION)
 
 .PHONY: generate
 generate: export CFLAGS := $(BPF_HEADERS)
@@ -38,7 +38,7 @@ docker-generate:
 build:
 	CGO_ENABLED=1 GOOS=linux \
 		go build \
-			--ldflags "-X main.Version=$(RELEASE_VERSION)" \
+			--ldflags "-X main.Version=$(REL_VERSION)" \
 			-o hny-network-agent main.go
 
 .PHONY: docker-build

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ ifeq (,$(wildcard /sys/kernel/btf/vmlinux))
 	BPF_HEADERS += -DBPF_NO_PRESERVE_ACCESS_INDEX
 endif
 
-# I_MADE_THIS_UP ?= $(shell git describe --always --match "v[0-9]*")
-I_MADE_THIS_UP ?= v0.0.14-alpha-8-g57c7eb0
+I_MADE_THIS_UP ?= $(shell git describe --always --match "v[0-9]*")
 IMG_NAME ?= hny/network-agent
 IMG_TAG ?= local
 
@@ -39,7 +38,7 @@ docker-generate:
 build:
 	CGO_ENABLED=1 GOOS=linux \
 		go build \
-			--ldflags "-X main.Version=v0.0.14-alpha-8-g57c7eb0" \
+			--ldflags "-X main.Version=$(I_MADE_THIS_UP)" \
 			-o hny-network-agent main.go
 
 .PHONY: docker-build

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,14 @@ ifeq (,$(wildcard /sys/kernel/btf/vmlinux))
 	BPF_HEADERS += -DBPF_NO_PRESERVE_ACCESS_INDEX
 endif
 
-REL_VERSION ?= $(shell git describe --always --match "v[0-9]*")
+I_MADE_THIS_UP ?= $(shell git describe --always --match "v[0-9]*")
 IMG_NAME ?= hny/network-agent
 IMG_TAG ?= local
 
 .PHONY: version
 #: display the current computed project version
 version:
-	@echo $(REL_VERSION)
+	@echo $(I_MADE_THIS_UP)
 
 .PHONY: generate
 generate: export CFLAGS := $(BPF_HEADERS)
@@ -38,7 +38,7 @@ docker-generate:
 build:
 	CGO_ENABLED=1 GOOS=linux \
 		go build \
-			--ldflags "-X main.Version=$(REL_VERSION)" \
+			--ldflags "-X main.Version=$(I_MADE_THIS_UP)" \
 			-o hny-network-agent main.go
 
 .PHONY: docker-build


### PR DESCRIPTION
## Which problem is this PR solving?

- Tried to work on #192 
- Now this might close #213 

## Short description of the changes

- try changing `RELEASE_VERSION` variable to `REL_VERSION` in case it's being used already in GHA workflow somewhere.

## How to verify that this has the expected result

Review the output in the action for docker-build on the PR. Search for "ldflags" and confirm the `"-X main.Version=ca4d958"` instead shows `"-X main.Version=v0.0.14-alpha-6-gca4d958"` instead of `ca4d958`.

(It should be v0.0.15-alpha but the previous tag was not annotated)

```
#16 [builder 7/7] RUN make build
#16 0.130 CGO_ENABLED=1 GOOS=linux \
#16 0.130 	go build \
#16 0.130 		--ldflags "-X main.Version=v0.0.14-alpha-6-gca4d958" \
#16 0.130 		-o hny-network-agent main.go
#16 DONE 86.4s
```