### PR TITLE
maint: add more comments and some var name refactoring to httpMatcher

### DIFF
--- a/assemblers/http_matcher.go
+++ b/assemblers/http_matcher.go
@@ -25,15 +25,17 @@ func newRequestResponseMatcher() *httpMatcher {
 
 // GetOrStoreRequest receives a tcpStream ident, a timestamp, and a request.
 //
-// If the response that matches the stream ident has been seen before, return an entry with both Request and Response.
+// If the response that matches the stream ident has been seen before,
+// returns a match entry containing both Request and Response and matchFound will be true.
 //
-// If the response hasn't been seen yet, store the Request for later lookup.
-func (m *httpMatcher) GetOrStoreRequest(ident string, timestamp time.Time, request *http.Request) (*entry, bool) {
+// If the response hasn't been seen yet,
+// stores the Request for later lookup and returns match as nil and matchFound will be false.
+func (m *httpMatcher) GetOrStoreRequest(ident string, timestamp time.Time, request *http.Request) (match *entry, matchFound bool) {
 	e := &entry{
 		request:          request,
 		requestTimestamp: timestamp,
 	}
-	if v, ok := m.messages.LoadOrStore(ident, e); ok {
+	if v, loaded := m.messages.LoadOrStore(ident, e); loaded {
 		m.messages.Delete(ident)
 		e = v.(*entry)
 		e.request = request
@@ -45,15 +47,17 @@ func (m *httpMatcher) GetOrStoreRequest(ident string, timestamp time.Time, reque
 
 // GetOrStoreResponse receives a tcpStream ident, a timestamp, and a response.
 //
-// If the request that matches the stream ident has been seen before, return an entry with both Request and Response.
+// If the request that matches the stream ident has been seen before,
+// returns a match entry containing both Request and Response and matchFound will be true.
 //
-// If the request hasn't been seen yet, store the Response for later lookup.
-func (m *httpMatcher) GetOrStoreResponse(ident string, timestamp time.Time, response *http.Response) (*entry, bool) {
+// If the request hasn't been seen yet,
+// stores the Response for later lookup and returns match as nil and matchFound will be false.
+func (m *httpMatcher) GetOrStoreResponse(ident string, timestamp time.Time, response *http.Response) (match *entry, matchFound bool) {
 	e := &entry{
 		response:          response,
 		responseTimestamp: timestamp,
 	}
-	if v, ok := m.messages.LoadOrStore(ident, e); ok {
+	if v, loaded := m.messages.LoadOrStore(ident, e); loaded {
 		m.messages.Delete(ident)
 		e = v.(*entry)
 		e.response = response

--- a/assemblers/http_matcher.go
+++ b/assemblers/http_matcher.go
@@ -35,9 +35,12 @@ func (m *httpMatcher) GetOrStoreRequest(ident string, timestamp time.Time, reque
 		request:          request,
 		requestTimestamp: timestamp,
 	}
+
 	if v, loaded := m.entries.LoadOrStore(ident, e); loaded {
+		// matching entry found
 		m.entries.Delete(ident)
-		e = v.(*entry)
+		e = v.(*entry) // reuse allocated &entry{} to hold the match
+		// found entry has Response, so update it with Request
 		e.request = request
 		e.requestTimestamp = timestamp
 		return e, true
@@ -57,9 +60,12 @@ func (m *httpMatcher) GetOrStoreResponse(ident string, timestamp time.Time, resp
 		response:          response,
 		responseTimestamp: timestamp,
 	}
+
 	if v, loaded := m.entries.LoadOrStore(ident, e); loaded {
+		// matching entry found
 		m.entries.Delete(ident)
-		e = v.(*entry)
+		e = v.(*entry) // reuse allocated &entry{} to hold the match
+		// found entry has Request, so update it with Response
 		e.response = response
 		e.responseTimestamp = timestamp
 		return e, true

--- a/assemblers/http_matcher.go
+++ b/assemblers/http_matcher.go
@@ -7,7 +7,7 @@ import (
 )
 
 type httpMatcher struct {
-	messages *sync.Map
+	entries *sync.Map
 }
 
 type entry struct {
@@ -19,7 +19,7 @@ type entry struct {
 
 func newRequestResponseMatcher() *httpMatcher {
 	return &httpMatcher{
-		messages: &sync.Map{},
+		entries: &sync.Map{},
 	}
 }
 
@@ -35,8 +35,8 @@ func (m *httpMatcher) GetOrStoreRequest(ident string, timestamp time.Time, reque
 		request:          request,
 		requestTimestamp: timestamp,
 	}
-	if v, loaded := m.messages.LoadOrStore(ident, e); loaded {
-		m.messages.Delete(ident)
+	if v, loaded := m.entries.LoadOrStore(ident, e); loaded {
+		m.entries.Delete(ident)
 		e = v.(*entry)
 		e.request = request
 		e.requestTimestamp = timestamp
@@ -57,8 +57,8 @@ func (m *httpMatcher) GetOrStoreResponse(ident string, timestamp time.Time, resp
 		response:          response,
 		responseTimestamp: timestamp,
 	}
-	if v, loaded := m.messages.LoadOrStore(ident, e); loaded {
-		m.messages.Delete(ident)
+	if v, loaded := m.entries.LoadOrStore(ident, e); loaded {
+		m.entries.Delete(ident)
 		e = v.(*entry)
 		e.response = response
 		e.responseTimestamp = timestamp

--- a/assemblers/tcp_reader.go
+++ b/assemblers/tcp_reader.go
@@ -71,7 +71,7 @@ func (reader *tcpReader) reassembledSG(sg reassembly.ScatterGather, ac reassembl
 			req.Body.Close()
 		}
 
-		if entry, ok := reader.matcher.GetOrStoreRequest(reqIdent, ctx.CaptureInfo.Timestamp, req); ok {
+		if entry, matchFound := reader.matcher.GetOrStoreRequest(reqIdent, ctx.CaptureInfo.Timestamp, req); matchFound {
 			// we have a match, process complete request/response pair
 			reader.processEvent(reqIdent, entry)
 		}
@@ -95,7 +95,7 @@ func (reader *tcpReader) reassembledSG(sg reassembly.ScatterGather, ac reassembl
 			res.Body.Close()
 		}
 
-		if entry, ok := reader.matcher.GetOrStoreResponse(resIdent, ctx.CaptureInfo.Timestamp, res); ok {
+		if entry, matchFound := reader.matcher.GetOrStoreResponse(resIdent, ctx.CaptureInfo.Timestamp, res); matchFound {
 			// we have a match, process complete request/response pair
 			reader.processEvent(resIdent, entry)
 		}


### PR DESCRIPTION
## Which problem is this PR solving?

httpMatcher and its directions confuse me every time I revisit it. So in reviewing #157, I thought I would add more comments and rename some variables to decrease cognitive load in reading this code.

## Short description of the changes

- Add some more doc comments and variable renaming/refactoring to httpMatcher

## How to verify that this has the expected result

The new tests still pass! Do these comments and names make sense?