### PR TITLE
docs: Replace namespace and secret files with kubectl cmds in README

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -45,7 +45,7 @@ For example, to get a local docker image called `hny/network-agent-go:custom`:
 
 ## Deploying the agent to a Kubernetes cluster
 
-Set environment variables like `HONEYCOMB_API_KEY` and the previously noted `GITHUB_TOKEN` and `BASE64_TOKEN` in a file called `.env`.
+Set environment variables like `HONEYCOMB_API_KEY` in a file called `.env`.
 These environment variables get passed in the make command.
 
 `make apply-network-agent`

--- a/README.md
+++ b/README.md
@@ -15,17 +15,16 @@ See notes on local development in [`DEVELOPING.md`](./DEVELOPING.md)
 
 - A running Kubernetes cluster (see [Supported Versions](#supported-versions))
 - A Honeycomb API Key
-- A classic [personal access token](https://github.com/settings/tokens) from GitHub with `read:packages` permission
 
 ### Setup
 
-Create honeycomb namespace:
+Create Honeycomb namespace for the agent to run in:
 
 ```sh
-kubectl apply -f examples/ns.yaml
+kubectl create namespace honeycomb
 ```
 
-Create secret for `HONEYCOMB_API_KEY` (alternatively, use `examples/secret-honeycomb.yaml`):
+Create Honeycomb secret for `HONEYCOMB_API_KEY` environment variable so it can be passed into the agent:
 
 ```sh
 export HONEYCOMB_API_KEY=mykey

--- a/examples/ns.yaml
+++ b/examples/ns.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: honeycomb
-spec: {}
-status: {}

--- a/examples/secret-honeycomb.yaml
+++ b/examples/secret-honeycomb.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: honeycomb
-  namespace: honeycomb
-type: Opaque
-stringData:
-  # export HONEYCOMB_API_KEY env var
-  api-key: $HONEYCOMB_API_KEY


### PR DESCRIPTION
## Which problem is this PR solving?
A few more tweaks to the README for quickstart example instructions.

## Short description of the changes
- Replace namespace and secret resource files with kubectl commands
- Remove unused namespace and secret resource files
- Remove reference to GITHUB_TOKEN and BASE64 in developing.md

## How to verify that this has the expected result
Instructions for running the agent using quick start guide is simpler.