### PR TITLE
maint: Consolidate dockerfiles and update deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM golang:1.20 as builder
-RUN apt update -yq && apt install -yq clang llvm make libpcap-dev
+FROM golang:1.20 as base
+RUN apt update -yq && apt install -yq make libpcap-dev
 WORKDIR /src
 COPY go.* .
 RUN go mod download
 COPY . .
 RUN make build
 
-FROM ubuntu:22.04
+FROM base as test
+RUN make test
+
+FROM ubuntu:22.04 as build
 RUN apt-get update -yq && apt-get install -yq ca-certificates libpcap-dev
-COPY --from=builder /src/hny-network-agent /bin/hny-network-agent
+COPY --from=base /src/hny-network-agent /bin/hny-network-agent
 ENTRYPOINT [ "/bin/hny-network-agent" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ RUN go mod download
 COPY . .
 RUN make build
 
-FROM base as test
-RUN make test
-
 FROM ubuntu:22.04 as build
 RUN apt-get update -yq && apt-get install -yq ca-certificates libpcap-dev
 COPY --from=base /src/hny-network-agent /bin/hny-network-agent
 ENTRYPOINT [ "/bin/hny-network-agent" ]
+
+FROM base as test
+RUN make test

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,0 @@
-FROM golang:1.20 as builder
-RUN apt update -yq && apt install -yq clang llvm make libpcap-dev
-WORKDIR /src
-COPY go.* .
-RUN go mod download
-COPY . .
-RUN make test

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 .PHONY: docker-build
 #: build the agent image
 docker-build:
-	docker build --tag $(IMG_NAME):$(IMG_TAG) .
+	docker build --target build --tag $(IMG_NAME):$(IMG_TAG) .
 
 .PHONY: test
 #: run unit tests
@@ -18,7 +18,7 @@ test:
 .PHONY: docker-test
 #: run unit tests in docker
 docker-test:
-	docker build -f Dockerfile.test .
+	docker build --target test .
 
 ### Testing targets
 


### PR DESCRIPTION
## Which problem is this PR solving?
We maintain two Dockerfiles, one for test and one for building and tagging. This has a maintenance burden of updating both dockerfiles whenever changes are needed.

This PR consolidates both Dockerfiles and uses build stages for test and build so we can target what stage we want.

## Short description of the changes
- Consolidates Dockerfile Dockerfile.test by adding test build stage
- Remove unused clang and llvm dependencies from base stage
- Update Makefile docker-build and docker-test targets to set the desired docker build stage

## How to verify that this has the expected result
We now only have one dockerfile we have to maintain and both both build and test makefile targets use the same one.