### PR TITLE
feat: update to OTel semconv v1.21.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,8 +133,8 @@ func sendHttpEventToHoneycomb(event assemblers.HttpEvent, k8sClient *utils.Cache
 
 	// response attributes
 	if event.Response != nil {
-		ev.AddField(string(semconv.HTTPStatusCodeKey), event.Response.StatusCode)
-		ev.AddField("http.response.body.size", event.Response.ContentLength)
+		ev.AddField(string(semconv.HTTPResponseStatusCodeKey), event.Response.StatusCode)
+		ev.AddField(string(semconv.HTTPResponseBodySizeKey), event.Response.ContentLength)
 
 	} else {
 		ev.AddField("http.response.missing", "no response on this event")

--- a/main.go
+++ b/main.go
@@ -122,10 +122,10 @@ func sendHttpEventToHoneycomb(event assemblers.HttpEvent, k8sClient *utils.Cache
 	if event.Request != nil {
 		requestURI = event.Request.RequestURI
 		ev.AddField("name", fmt.Sprintf("HTTP %s", event.Request.Method))
-		ev.AddField(string(semconv.HTTPMethodKey), event.Request.Method)
-		ev.AddField(string(semconv.HTTPURLKey), requestURI)
+		ev.AddField(string(semconv.HTTPRequestMethodKey), event.Request.Method)
+		ev.AddField(string(semconv.URLPathKey), requestURI)
 		ev.AddField(string(semconv.UserAgentOriginalKey), event.Request.Header.Get("User-Agent"))
-		ev.AddField("http.request.body.size", event.Request.ContentLength)
+		ev.AddField(string(semconv.HTTPRequestBodySizeKey), event.Request.ContentLength)
 	} else {
 		ev.AddField("name", "HTTP")
 		ev.AddField("http.request.missing", "no request on this event")

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
 
 const Version string = "0.0.17-alpha"

--- a/main.go
+++ b/main.go
@@ -113,8 +113,8 @@ func sendHttpEventToHoneycomb(event assemblers.HttpEvent, k8sClient *utils.Cache
 	ev.AddField("http.response.timestamp", event.ResponseTimestamp)
 	ev.AddField("http.request.id", event.RequestId)
 
-	ev.AddField(string(semconv.NetSockHostAddrKey), event.SrcIp)
-	ev.AddField("destination.address", event.DstIp)
+	ev.AddField(string(semconv.ClientSocketAddressKey), event.SrcIp)
+	ev.AddField(string(semconv.ServerSocketAddressKey), event.DstIp)
 
 	var requestURI string
 

--- a/main_test.go
+++ b/main_test.go
@@ -51,19 +51,19 @@ func Test_sendHttpEventToHoneycomb(t *testing.T) {
 	delete(attrs, "meta.httpEvent_response_handled_latency_ms")
 
 	expectedAttrs := map[string]interface{}{
-		"name":                    "HTTP GET",
-		"net.sock.host.addr":      "1.2.3.4",
-		"destination.address":     "5.6.7.8",
-		"http.request.id":         "c->s:1->2",
-		"http.method":             "GET",
-		"http.url":                "/check?teapot=true",
-		"http.request.body.size":  int64(42),
-		"http.request.timestamp":  testReqTime,
-		"http.response.timestamp": testReqTime.Add(3 * time.Millisecond),
-		"http.status_code":        418,
-		"http.response.body.size": int64(84),
-		"duration_ms":             int64(3),
-		"user_agent.original":     "teapot-checker/1.0",
+		"name":                      "HTTP GET",
+		"client.socket.address":     "1.2.3.4",
+		"server.socket.address":     "5.6.7.8",
+		"http.request.id":           "c->s:1->2",
+		"http.request.method":       "GET",
+		"url.path":                  "/check?teapot=true",
+		"http.request.body.size":    int64(42),
+		"http.request.timestamp":    testReqTime,
+		"http.response.timestamp":   testReqTime.Add(3 * time.Millisecond),
+		"http.response.status_code": 418,
+		"http.response.body.size":   int64(84),
+		"duration_ms":               int64(3),
+		"user_agent.original":       "teapot-checker/1.0",
 	}
 
 	assert.Equal(t, expectedAttrs, attrs)

--- a/main_test.go
+++ b/main_test.go
@@ -19,7 +19,7 @@ func Test_sendHttpEventToHoneycomb(t *testing.T) {
 	testReqTime := time.Now()
 
 	httpEvent := assemblers.HttpEvent{
-		RequestId: "c->s:1->2",
+		StreamIdent: "c->s:1->2",
 		Request: &http.Request{
 			Method:        "GET",
 			RequestURI:    "/check?teapot=true",
@@ -54,7 +54,7 @@ func Test_sendHttpEventToHoneycomb(t *testing.T) {
 		"name":                      "HTTP GET",
 		"client.socket.address":     "1.2.3.4",
 		"server.socket.address":     "5.6.7.8",
-		"http.request.id":           "c->s:1->2",
+		"meta.stream.ident":         "c->s:1->2",
 		"http.request.method":       "GET",
 		"url.path":                  "/check?teapot=true",
 		"http.request.body.size":    int64(42),

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/honeycombio/honeycomb-network-agent/assemblers"
+	"github.com/honeycombio/honeycomb-network-agent/utils"
+	"github.com/honeycombio/libhoney-go"
+	"github.com/honeycombio/libhoney-go/transmission"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+)
+
+func Test_sendHttpEventToHoneycomb(t *testing.T) {
+	mockTransmission := setupTestLibhoney(t)
+
+	testReqTime := time.Now()
+
+	httpEvent := assemblers.HttpEvent{
+		RequestId: "c->s:1->2",
+		Request: &http.Request{
+			Method:        "GET",
+			RequestURI:    "/check?teapot=true",
+			ContentLength: 42,
+			Header:        http.Header{"User-Agent": []string{"teapot-checker/1.0"}},
+		},
+		Response: &http.Response{
+			StatusCode:    418,
+			ContentLength: 84,
+		},
+		RequestTimestamp:  testReqTime,
+		ResponseTimestamp: testReqTime.Add(3 * time.Millisecond),
+		SrcIp:             "1.2.3.4",
+		DstIp:             "5.6.7.8",
+	}
+
+	sendHttpEventToHoneycomb(
+		httpEvent,
+		utils.NewCachedK8sClient(&kubernetes.Clientset{}), // TODO: mock the k8s metadata, silence for now
+	)
+
+	events := mockTransmission.Events()
+	assert.Equal(t, 1, len(events), "Expected 1 and only 1 event to be sent")
+
+	attrs := events[0].Data
+	// remove dynamic time-based data before comparing
+	delete(attrs, "meta.httpEvent_handled_at")
+	delete(attrs, "meta.httpEvent_request_handled_latency_ms")
+	delete(attrs, "meta.httpEvent_response_handled_latency_ms")
+
+	expectedAttrs := map[string]interface{}{
+		"name":                    "HTTP GET",
+		"net.sock.host.addr":      "1.2.3.4",
+		"destination.address":     "5.6.7.8",
+		"http.request.id":         "c->s:1->2",
+		"http.method":             "GET",
+		"http.url":                "/check?teapot=true",
+		"http.request.body.size":  int64(42),
+		"http.request.timestamp":  testReqTime,
+		"http.response.timestamp": testReqTime.Add(3 * time.Millisecond),
+		"http.status_code":        418,
+		"http.response.body.size": int64(84),
+		"duration_ms":             int64(3),
+		"user_agent.original":     "teapot-checker/1.0",
+	}
+
+	assert.Equal(t, expectedAttrs, attrs)
+}
+
+func setupTestLibhoney(t testing.TB) *transmission.MockSender {
+	mockTransmission := &transmission.MockSender{}
+	err := libhoney.Init(
+		libhoney.Config{
+			APIKey:       "placeholder",
+			Dataset:      "placeholder",
+			APIHost:      "placeholder",
+			Transmission: mockTransmission,
+		},
+	)
+	assert.NoError(t, err, "Failed to setup libhoney for testing")
+
+	return mockTransmission
+}

--- a/utils/k8sutils.go
+++ b/utils/k8sutils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
 
 func GetK8sEventAttrs(client *CachedK8sClient, srcIp string, dstIp string) map[string]any {


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #133 

## Short description of the changes

* update semconv usage to v1.21.0

### use stable HTTP response attr names
    
* `http.response.body.size` (no change, but use semconv constant)
* `http.status_code` -> `http.response.status_code`

### use stable HTTP request attr names

* `http.request.body.size` (no change, but use constant)
* `http.method` -> `http.request.method`
* `http.url` -> `url.path`
    
"RequestURI is the unmodified request-target of the Request-Line (RFC 7230, Section 3.1.1) as sent by the client to a server." So RequestURI is the path + query params. `url.path` is the closest to correct attribute to set until we opt to do more parsing of a request.

### use stable client/server address keys

* `net.sock.host.addr` -> `client.socket.address`
* `destination.address` -> `server.socket.address`

## How to verify that this has the expected result

Run the agent!

Is now the time to add transform unit tests or smoke tests? It would make changes to event output more visible in PRs.