### PR TITLE
feat: Add agent k8s metadata to events

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,9 @@ type Config struct {
 
 	// The name of the service account the agent is running as.
 	ServiceAccount string
+
+	// The IP address of the pod the agent is running on.
+	PodIP string
 }
 
 // NewConfig returns a new Config struct.
@@ -127,6 +130,7 @@ func NewConfig() Config {
 		NodeIP:                        utils.LookupEnvOrString("AGENT_NODE_IP", ""),
 		NodeName:                      utils.LookupEnvOrString("AGENT_NODE_NAME", ""),
 		ServiceAccount:                utils.LookupEnvOrString("AGENT_SERVICE_ACCOUNT_NAME", ""),
+		PodIP:                         utils.LookupEnvOrString("AGENT_POD_IP", ""),
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -88,16 +88,16 @@ type Config struct {
 	MaxBufferedPagesPerConnection int
 
 	// The IP address of the node the agent is running on.
-	NodeIP string
+	AgentNodeIP string
 
 	// The name of the node the agent is running on.
-	NodeName string
+	AgentNodeName string
 
 	// The name of the service account the agent is running as.
-	ServiceAccount string
+	AgentServiceAccount string
 
 	// The IP address of the pod the agent is running on.
-	PodIP string
+	AgentPodIP string
 }
 
 // NewConfig returns a new Config struct.
@@ -127,10 +127,10 @@ func NewConfig() Config {
 		ChannelBufferSize:             1000,
 		MaxBufferedPagesTotal:         150_000,
 		MaxBufferedPagesPerConnection: 4000,
-		NodeIP:                        utils.LookupEnvOrString("AGENT_NODE_IP", ""),
-		NodeName:                      utils.LookupEnvOrString("AGENT_NODE_NAME", ""),
-		ServiceAccount:                utils.LookupEnvOrString("AGENT_SERVICE_ACCOUNT_NAME", ""),
-		PodIP:                         utils.LookupEnvOrString("AGENT_POD_IP", ""),
+		AgentNodeIP:                   utils.LookupEnvOrString("AGENT_NODE_IP", ""),
+		AgentNodeName:                 utils.LookupEnvOrString("AGENT_NODE_NAME", ""),
+		AgentServiceAccount:           utils.LookupEnvOrString("AGENT_SERVICE_ACCOUNT_NAME", ""),
+		AgentPodIP:                    utils.LookupEnvOrString("AGENT_POD_IP", ""),
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -98,6 +98,9 @@ type Config struct {
 
 	// The IP address of the pod the agent is running on.
 	AgentPodIP string
+
+	// The name of the pod the agent is running on.
+	AgentPodName string
 }
 
 // NewConfig returns a new Config struct.
@@ -131,6 +134,7 @@ func NewConfig() Config {
 		AgentNodeName:                 utils.LookupEnvOrString("AGENT_NODE_NAME", ""),
 		AgentServiceAccount:           utils.LookupEnvOrString("AGENT_SERVICE_ACCOUNT_NAME", ""),
 		AgentPodIP:                    utils.LookupEnvOrString("AGENT_POD_IP", ""),
+		AgentPodName:                  utils.LookupEnvOrString("AGENT_POD_NAME", ""),
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -86,6 +86,15 @@ type Config struct {
 
 	// Maximum number of TCP reassembly pages per connection.
 	MaxBufferedPagesPerConnection int
+
+	// The IP address of the node the agent is running on.
+	NodeIP string
+
+	// The name of the node the agent is running on.
+	NodeName string
+
+	// The name of the service account the agent is running as.
+	ServiceAccount string
 }
 
 // NewConfig returns a new Config struct.
@@ -115,6 +124,9 @@ func NewConfig() Config {
 		ChannelBufferSize:             1000,
 		MaxBufferedPagesTotal:         150_000,
 		MaxBufferedPagesPerConnection: 4000,
+		NodeIP:                        utils.LookupEnvOrString("AGENT_NODE_IP", ""),
+		NodeName:                      utils.LookupEnvOrString("AGENT_NODE_NAME", ""),
+		ServiceAccount:                utils.LookupEnvOrString("AGENT_SERVICE_ACCOUNT_NAME", ""),
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,6 +55,10 @@ func TestEnvVars(t *testing.T) {
 	t.Setenv("LOG_LEVEL", "DEBUG")
 	t.Setenv("DEBUG", "true")
 	t.Setenv("DEBUG_ADDRESS", "1.2.3.4:5678")
+	t.Setenv("AGENT_NODE_IP", "node_ip")
+	t.Setenv("AGENT_NODE_NAME", "node_name")
+	t.Setenv("AGENT_SERVICE_ACCOUNT_NAME", "service_account_name")
+	t.Setenv("AGENT_POD_IP", "pod_ip")
 
 	config := config.NewConfig()
 	assert.Equal(t, "1234567890123456789012", config.APIKey)
@@ -64,4 +68,8 @@ func TestEnvVars(t *testing.T) {
 	assert.Equal(t, "DEBUG", config.LogLevel)
 	assert.Equal(t, true, config.Debug)
 	assert.Equal(t, "1.2.3.4:5678", config.DebugAddress)
+	assert.Equal(t, "node_ip", config.AgentNodeIP)
+	assert.Equal(t, "node_name", config.AgentNodeName)
+	assert.Equal(t, "service_account_name", config.AgentServiceAccount)
+	assert.Equal(t, "pod_ip", config.AgentPodIP)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -59,6 +59,7 @@ func TestEnvVars(t *testing.T) {
 	t.Setenv("AGENT_NODE_NAME", "node_name")
 	t.Setenv("AGENT_SERVICE_ACCOUNT_NAME", "service_account_name")
 	t.Setenv("AGENT_POD_IP", "pod_ip")
+	t.Setenv("AGENT_POD_NAME", "pod_name")
 
 	config := config.NewConfig()
 	assert.Equal(t, "1234567890123456789012", config.APIKey)
@@ -72,4 +73,5 @@ func TestEnvVars(t *testing.T) {
 	assert.Equal(t, "node_name", config.AgentNodeName)
 	assert.Equal(t, "service_account_name", config.AgentServiceAccount)
 	assert.Equal(t, "pod_ip", config.AgentPodIP)
+	assert.Equal(t, "pod_name", config.AgentPodName)
 }

--- a/main.go
+++ b/main.go
@@ -116,6 +116,16 @@ func sendHttpEventToHoneycomb(event assemblers.HttpEvent, k8sClient *utils.Cache
 	ev.AddField(string(semconv.ClientSocketAddressKey), event.SrcIp)
 	ev.AddField(string(semconv.ServerSocketAddressKey), event.DstIp)
 
+	if nodeIP := os.Getenv("AGENT_NODE_IP"); nodeIP != "" {
+		ev.AddField("meta.agent.node.ip", nodeIP)
+	}
+	if nodeName := os.Getenv("AGENT_NODE_NAME"); nodeName != "" {
+		ev.AddField("meta.agent.node.name", nodeName)
+	}
+	if serviceAcctName := os.Getenv("AGENT_SERVICE_ACCOUNT_NAME"); serviceAcctName != "" {
+		ev.AddField("meta.agent.serviceaccount.name", serviceAcctName)
+	}
+
 	var requestURI string
 
 	// request attributes

--- a/main.go
+++ b/main.go
@@ -197,6 +197,7 @@ func setupLibhoney(config config.Config) func() {
 	if config.AgentServiceAccount != "" {
 		libhoney.AddField("meta.agent.serviceaccount.name", config.AgentServiceAccount)
 	}
+	// because we use hostnetwork in deployments, the pod IP and node IP are the same
 	if config.AgentPodIP != "" {
 		libhoney.AddField("meta.agent.pod.ip", config.AgentPodIP)
 	}

--- a/main.go
+++ b/main.go
@@ -118,17 +118,17 @@ func sendHttpEventToHoneycomb(config config.Config, event assemblers.HttpEvent, 
 	ev.AddField(string(semconv.ClientSocketAddressKey), event.SrcIp)
 	ev.AddField(string(semconv.ServerSocketAddressKey), event.DstIp)
 
-	if config.NodeIP != "" {
-		ev.AddField("meta.agent.node.ip", config.NodeIP)
+	if config.AgentNodeIP != "" {
+		ev.AddField("meta.agent.node.ip", config.AgentNodeIP)
 	}
-	if config.NodeName != "" {
-		ev.AddField("meta.agent.node.name", config.NodeName)
+	if config.AgentNodeName != "" {
+		ev.AddField("meta.agent.node.name", config.AgentNodeName)
 	}
-	if config.ServiceAccount != "" {
-		ev.AddField("meta.agent.serviceaccount.name", config.ServiceAccount)
+	if config.AgentServiceAccount != "" {
+		ev.AddField("meta.agent.serviceaccount.name", config.AgentServiceAccount)
 	}
-	if config.PodIP != "" {
-		ev.AddField("meta.agent.pod.ip", config.PodIP)
+	if config.AgentPodIP != "" {
+		ev.AddField("meta.agent.pod.ip", config.AgentPodIP)
 	}
 
 	var requestURI string

--- a/main.go
+++ b/main.go
@@ -133,8 +133,8 @@ func sendHttpEventToHoneycomb(event assemblers.HttpEvent, k8sClient *utils.Cache
 
 	// response attributes
 	if event.Response != nil {
-		ev.AddField(string(semconv.HTTPStatusCodeKey), event.Response.StatusCode)
-		ev.AddField("http.response.body.size", event.Response.ContentLength)
+		ev.AddField(string(semconv.HTTPResponseStatusCodeKey), event.Response.StatusCode)
+		ev.AddField(string(semconv.HTTPResponseBodySizeKey), event.Response.ContentLength)
 
 	} else {
 		ev.AddField("http.response.missing", "no response on this event")

--- a/main.go
+++ b/main.go
@@ -201,6 +201,9 @@ func setupLibhoney(config config.Config) func() {
 	if config.AgentPodIP != "" {
 		libhoney.AddField("meta.agent.pod.ip", config.AgentPodIP)
 	}
+	if config.AgentPodName != "" {
+		libhoney.AddField("meta.agent.pod.name", config.AgentPodName)
+	}
 
 	return libhoney.Close
 }

--- a/main.go
+++ b/main.go
@@ -122,10 +122,10 @@ func sendHttpEventToHoneycomb(event assemblers.HttpEvent, k8sClient *utils.Cache
 	if event.Request != nil {
 		requestURI = event.Request.RequestURI
 		ev.AddField("name", fmt.Sprintf("HTTP %s", event.Request.Method))
-		ev.AddField(string(semconv.HTTPMethodKey), event.Request.Method)
-		ev.AddField(string(semconv.HTTPURLKey), requestURI)
+		ev.AddField(string(semconv.HTTPRequestMethodKey), event.Request.Method)
+		ev.AddField(string(semconv.URLPathKey), requestURI)
 		ev.AddField(string(semconv.UserAgentOriginalKey), event.Request.Header.Get("User-Agent"))
-		ev.AddField("http.request.body.size", event.Request.ContentLength)
+		ev.AddField(string(semconv.HTTPRequestBodySizeKey), event.Request.ContentLength)
 	} else {
 		ev.AddField("name", "HTTP")
 		ev.AddField("http.request.missing", "no request on this event")

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
 
 const Version string = "0.0.17-alpha"

--- a/main.go
+++ b/main.go
@@ -113,8 +113,8 @@ func sendHttpEventToHoneycomb(event assemblers.HttpEvent, k8sClient *utils.Cache
 	ev.AddField("http.response.timestamp", event.ResponseTimestamp)
 	ev.AddField("http.request.id", event.RequestId)
 
-	ev.AddField(string(semconv.NetSockHostAddrKey), event.SrcIp)
-	ev.AddField("destination.address", event.DstIp)
+	ev.AddField(string(semconv.ClientSocketAddressKey), event.SrcIp)
+	ev.AddField(string(semconv.ServerSocketAddressKey), event.DstIp)
 
 	var requestURI string
 

--- a/main.go
+++ b/main.go
@@ -127,6 +127,9 @@ func sendHttpEventToHoneycomb(config config.Config, event assemblers.HttpEvent, 
 	if config.ServiceAccount != "" {
 		ev.AddField("meta.agent.serviceaccount.name", config.ServiceAccount)
 	}
+	if config.PodIP != "" {
+		ev.AddField("meta.agent.pod.ip", config.PodIP)
+	}
 
 	var requestURI string
 

--- a/smoke-tests/deployment.yaml
+++ b/smoke-tests/deployment.yaml
@@ -97,6 +97,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: AGENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/smoke-tests/deployment.yaml
+++ b/smoke-tests/deployment.yaml
@@ -93,6 +93,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
+            - name: AGENT_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/smoke-tests/deployment.yaml
+++ b/smoke-tests/deployment.yaml
@@ -80,6 +80,19 @@ spec:
           # ports:
           #   - containerPort: 6060
           env:
+          # https://kubernetes.io/docs/concepts/workloads/pods/downward-api/
+            - name: AGENT_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: AGENT_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: AGENT_SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             - name: HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/utils/k8sutils.go
+++ b/utils/k8sutils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
 
 func GetK8sEventAttrs(client *CachedK8sClient, srcIp string, dstIp string) map[string]any {

--- a/utils/k8sutils.go
+++ b/utils/k8sutils.go
@@ -19,30 +19,50 @@ func GetK8sEventAttrs(client *CachedK8sClient, srcIp string, dstIp string) map[s
 	if srcPod := client.GetPodByIPAddr(srcIp); srcPod != nil {
 		k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SPodNameKey)] = srcPod.Name
 		k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SPodUIDKey)] = srcPod.UID
-		k8sEventAttrs[string(semconv.K8SNamespaceNameKey)] = srcPod.Namespace
+		k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SNamespaceNameKey)] = srcPod.Namespace
 
 		if len(srcPod.Spec.Containers) > 0 {
 			var containerNames []string
 			for _, container := range srcPod.Spec.Containers {
 				containerNames = append(containerNames, container.Name)
 			}
-			k8sEventAttrs[string(semconv.K8SContainerNameKey)] = strings.Join(containerNames, ",")
+			k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SContainerNameKey)] = strings.Join(containerNames, ",")
 		}
 
 		if srcNode := client.GetNodeByPod(srcPod); srcNode != nil {
-			k8sEventAttrs[string(semconv.K8SNodeNameKey)] = srcNode.Name
-			k8sEventAttrs[string(semconv.K8SNodeUIDKey)] = srcNode.UID
+			k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SNodeNameKey)] = srcNode.Name
+			k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SNodeUIDKey)] = srcNode.UID
 		}
 
 		if service := client.GetServiceForPod(srcPod); service != nil {
 			// no semconv for service yet
-			k8sEventAttrs["k8s.service.name"] = service.Name
+			k8sEventAttrs["source.k8s.service.name"] = service.Name
 		}
 	}
 
 	if dstPod := client.GetPodByIPAddr(dstIp); dstPod != nil {
 		k8sEventAttrs[fmt.Sprintf("destination.%s", semconv.K8SPodNameKey)] = dstPod.Name
 		k8sEventAttrs[fmt.Sprintf("destination.%s", semconv.K8SPodUIDKey)] = dstPod.UID
+		k8sEventAttrs[fmt.Sprintf("destination.%s", semconv.K8SNamespaceNameKey)] = dstPod.Namespace
+
+		if len(dstPod.Spec.Containers) > 0 {
+			var containerNames []string
+			for _, container := range dstPod.Spec.Containers {
+				containerNames = append(containerNames, container.Name)
+			}
+			k8sEventAttrs[fmt.Sprintf("destination.%s", semconv.K8SContainerNameKey)] = strings.Join(containerNames, ",")
+		}
+
+		if srcNode := client.GetNodeByPod(dstPod); srcNode != nil {
+			k8sEventAttrs[fmt.Sprintf("destination.%s", semconv.K8SNodeNameKey)] = srcNode.Name
+			k8sEventAttrs[fmt.Sprintf("destination.%s", semconv.K8SNodeUIDKey)] = srcNode.UID
+		}
+
+		if service := client.GetServiceForPod(dstPod); service != nil {
+			// no semconv for service yet
+			k8sEventAttrs["destination.k8s.service.name"] = service.Name
+		}
+
 	}
 
 	return k8sEventAttrs

--- a/utils/k8sutils.go
+++ b/utils/k8sutils.go
@@ -17,8 +17,8 @@ func GetK8sEventAttrs(client *CachedK8sClient, srcIp string, dstIp string) map[s
 	k8sEventAttrs := map[string]any{}
 
 	if srcPod := client.GetPodByIPAddr(srcIp); srcPod != nil {
-		k8sEventAttrs[string(semconv.K8SPodNameKey)] = srcPod.Name
-		k8sEventAttrs[string(semconv.K8SPodUIDKey)] = srcPod.UID
+		k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SPodNameKey)] = srcPod.Name
+		k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SPodUIDKey)] = srcPod.UID
 		k8sEventAttrs[string(semconv.K8SNamespaceNameKey)] = srcPod.Namespace
 
 		if len(srcPod.Spec.Containers) > 0 {

--- a/utils/k8sutils.go
+++ b/utils/k8sutils.go
@@ -15,54 +15,43 @@ func GetK8sEventAttrs(client *CachedK8sClient, srcIp string, dstIp string) map[s
 		Msg("Getting k8s event attrs")
 
 	k8sEventAttrs := map[string]any{}
+	var prefix string
+	var ip string
 
-	if srcPod := client.GetPodByIPAddr(srcIp); srcPod != nil {
-		k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SPodNameKey)] = srcPod.Name
-		k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SPodUIDKey)] = srcPod.UID
-		k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SNamespaceNameKey)] = srcPod.Namespace
-
-		if len(srcPod.Spec.Containers) > 0 {
-			var containerNames []string
-			for _, container := range srcPod.Spec.Containers {
-				containerNames = append(containerNames, container.Name)
-			}
-			k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SContainerNameKey)] = strings.Join(containerNames, ",")
-		}
-
-		if srcNode := client.GetNodeByPod(srcPod); srcNode != nil {
-			k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SNodeNameKey)] = srcNode.Name
-			k8sEventAttrs[fmt.Sprintf("source.%s", semconv.K8SNodeUIDKey)] = srcNode.UID
-		}
-
-		if service := client.GetServiceForPod(srcPod); service != nil {
-			// no semconv for service yet
-			k8sEventAttrs["source.k8s.service.name"] = service.Name
-		}
+	if srcIp != "" {
+		prefix = "source"
+		ip = srcIp
 	}
 
-	if dstPod := client.GetPodByIPAddr(dstIp); dstPod != nil {
-		k8sEventAttrs[fmt.Sprintf("destination.%s", semconv.K8SPodNameKey)] = dstPod.Name
-		k8sEventAttrs[fmt.Sprintf("destination.%s", semconv.K8SPodUIDKey)] = dstPod.UID
-		k8sEventAttrs[fmt.Sprintf("destination.%s", semconv.K8SNamespaceNameKey)] = dstPod.Namespace
+	if dstIp != "" {
+		prefix = "destination"
+		ip = dstIp
+	}
 
-		if len(dstPod.Spec.Containers) > 0 {
-			var containerNames []string
-			for _, container := range dstPod.Spec.Containers {
-				containerNames = append(containerNames, container.Name)
+	if prefix != "" {
+		if pod := client.GetPodByIPAddr(ip); pod != nil {
+			k8sEventAttrs[fmt.Sprintf("%s.%s", prefix, semconv.K8SPodNameKey)] = pod.Name
+			k8sEventAttrs[fmt.Sprintf("%s.%s", prefix, semconv.K8SPodUIDKey)] = pod.UID
+			k8sEventAttrs[fmt.Sprintf("%s.%s", prefix, semconv.K8SNamespaceNameKey)] = pod.Namespace
+
+			if len(pod.Spec.Containers) > 0 {
+				var containerNames []string
+				for _, container := range pod.Spec.Containers {
+					containerNames = append(containerNames, container.Name)
+				}
+				k8sEventAttrs[fmt.Sprintf("%s.%s", prefix, semconv.K8SContainerNameKey)] = strings.Join(containerNames, ",")
 			}
-			k8sEventAttrs[fmt.Sprintf("destination.%s", semconv.K8SContainerNameKey)] = strings.Join(containerNames, ",")
-		}
 
-		if srcNode := client.GetNodeByPod(dstPod); srcNode != nil {
-			k8sEventAttrs[fmt.Sprintf("destination.%s", semconv.K8SNodeNameKey)] = srcNode.Name
-			k8sEventAttrs[fmt.Sprintf("destination.%s", semconv.K8SNodeUIDKey)] = srcNode.UID
-		}
+			if node := client.GetNodeByPod(pod); node != nil {
+				k8sEventAttrs[fmt.Sprintf("%s.%s", prefix, semconv.K8SNodeNameKey)] = node.Name
+				k8sEventAttrs[fmt.Sprintf("%s.%s", prefix, semconv.K8SNodeUIDKey)] = node.UID
+			}
 
-		if service := client.GetServiceForPod(dstPod); service != nil {
-			// no semconv for service yet
-			k8sEventAttrs["destination.k8s.service.name"] = service.Name
+			if service := client.GetServiceForPod(pod); service != nil {
+				// no semconv for service yet
+				k8sEventAttrs[fmt.Sprintf("%s.k8s.service.name", prefix)] = service.Name
+			}
 		}
-
 	}
 
 	return k8sEventAttrs


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #224 

## Short description of the changes

Decorate events with the agent's metadata using the [Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/):

- `meta.agent.node.ip`
- `meta.agent.node.name`
- `meta.agent.serviceaccount.name`
- `meta.agent.pod.ip`
- `meta.agent.pod.name`

Note: Because we use `hostnetwork` in our deployments, host IP and pod IP are the same.

## How to verify that this has the expected result

Events in Honeycomb have the agent's metadata

<img width="1323" alt="image" src="https://github.com/honeycombio/honeycomb-network-agent/assets/3481731/a82b6298-1b50-4e8a-aac6-2ab612edb947">
