### PR TITLE
fix: Don’t send last assembler stats event on shutdown

### DIFF
--- a/assemblers/tcp_assembler.go
+++ b/assemblers/tcp_assembler.go
@@ -190,8 +190,6 @@ func (h *tcpAssembler) Stop() {
 		h.streamPool.Dump()
 	}
 
-	h.streamFactory.WaitGoRoutines()
-	h.logAssemblerStats()
 	log.Debug().
 		Int("closed", closed).
 		Str("assembler_page_usage", h.assembler.Dump()).

--- a/assemblers/tcp_stream_factory.go
+++ b/assemblers/tcp_stream_factory.go
@@ -1,8 +1,6 @@
 package assemblers
 
 import (
-	"sync"
-
 	"github.com/gopacket/gopacket"
 	"github.com/gopacket/gopacket/layers"
 	"github.com/gopacket/gopacket/reassembly"
@@ -12,7 +10,6 @@ import (
 
 type tcpStreamFactory struct {
 	config     config.Config
-	wg         sync.WaitGroup
 	httpEvents chan HttpEvent
 }
 
@@ -34,8 +31,4 @@ func (factory *tcpStreamFactory) New(net, transport gopacket.Flow, tcp *layers.T
 	// increment the number of active streams
 	IncrementActiveStreamCount()
 	return stream
-}
-
-func (factory *tcpStreamFactory) WaitGoRoutines() {
-	factory.wg.Wait()
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes a bug where the assembler panics during shutdown because it tries to send a last stats event but libhoney's transmission has been closed.

- Closes #228 

## Short description of the changes
- Don't send last stats event on shutdown, it's not neccesary
- Also cleans up the unused waitgroup in the assembler

## How to verify that this has the expected result
Agent does not panic during shutdown.