### PR TITLE
fix: append agent info to user-agent

### DIFF
--- a/main.go
+++ b/main.go
@@ -176,14 +176,14 @@ func setupLogging(c config.Config) {
 
 // setupLibhoney initializes libhoney and sets global fields
 func setupLibhoney(config config.Config) func() {
+	// appends libhoney's user-agent, has to happen before libhoney.Init()
+	libhoney.UserAgentAddition = fmt.Sprintf("hny-network-agent/%s", Version)
+
 	libhoney.Init(libhoney.Config{
 		APIKey:  config.APIKey,
 		Dataset: config.Dataset,
 		APIHost: config.Endpoint,
 	})
-
-	// appends libhoney's user-agent (TODO: doesn't work, no useragent right now)
-	libhoney.UserAgentAddition = fmt.Sprintf("hny-network-agent/%s", Version)
 
 	// configure global fields that are set on all events
 	libhoney.AddField("honeycomb.agent_version", Version)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- agent's telemetry export requests didn't have agent information in the user-agent

## Short description of the changes

- gotta set the user-agent in libhoney before calling init

## How to verify that this has the expected result

Run locally and check the user-agent captured by shepherd telemetry

![image](https://github.com/honeycombio/honeycomb-network-agent/assets/6738917/e77feb01-7983-4d44-b956-478a8025788b)

