### PR TITLE
maint: Update gitignore for direnv file names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@
 .terraform*
 terraform.tfstate*
 
-# dotenv
-.env
+# env files
+.env*
 
 # python cache (locust)
 __pycache__/


### PR DESCRIPTION
## Which problem is this PR solving?
We have a .gitignore entry for .env files to make local development easier. However, it only supports .env files and it would be nice to support direnv's .envrc files too.

## Short description of the changes
- Update .gitignore rule to allow both .env and .envrc files

## How to verify that this has the expected result
Both .env and .envrc files are ignored by git.