### PR TITLE
fix: add a waitgroup to coordinate shutdown

### DIFF
--- a/assemblers/tcp_assembler.go
+++ b/assemblers/tcp_assembler.go
@@ -3,6 +3,7 @@ package assemblers
 import (
 	"context"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -107,7 +108,9 @@ func NewTcpAssembler(config config.Config, httpEvents chan HttpEvent) tcpAssembl
 	}
 }
 
-func (h *tcpAssembler) Start(ctx context.Context) {
+func (h *tcpAssembler) Start(ctx context.Context, wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	log.Info().Msg("Starting TCP assembler")
 	// Tick on the tightest loop. The flush timeout is the shorter of the two timeouts using this ticker.
 	// Tick even more frequently than the flush interval (4 is somewhat arbitrary)

--- a/handlers/event_handler.go
+++ b/handlers/event_handler.go
@@ -2,12 +2,14 @@ package handlers
 
 import (
 	"context"
+	"sync"
 
 	"github.com/honeycombio/honeycomb-network-agent/assemblers"
 )
 
 // EventHandler is an interface for event handlers
 type EventHandler interface {
-	Start(ctx context.Context)
+	Start(ctx context.Context, wg *sync.WaitGroup)
+	Close()
 	handleEvent(event assemblers.HttpEvent)
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- followup to #230
- closes #228
- closes #237

## Short description of the changes

Use a sync.WaitGroup to ensure that both an assembler and an event handler have stopped generating data before clean-up and process exit.

Behind the curtain, the assembler is using the libhoney client managed within the event handler to ship assembler statistics. Closing that libhoney client has moved from the case statement in Start() to a separate Close() function on the event handler that is called after the wait group count indicates that all our internal routines have ended their loops.

How much of this interface is kept in an OTLP-flavored event handler (and stats producer?) remains TBD.

## How to verify that this has the expected result

No more intermittent panics on process exit?