### PR TITLE
maint: update target go version 1.20 -> 1.21

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.20.7
+golang 1.21.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as base
+FROM golang:1.21 as base
 RUN apt update -yq && apt install -yq make libpcap-dev
 WORKDIR /src
 COPY go.* .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/honeycomb-network-agent
 
-go 1.20
+go 1.21
 
 require (
 	github.com/gopacket/gopacket v1.1.1


### PR DESCRIPTION
## Which problem is this PR solving?

Current benefit: this removes a warning from my macOS dev environment during builds.

    ld: warning:
      '/private/var/folders/c_/shenanigans/T/go-link-2592252367/go.o'
      has malformed LC_DYSYMTAB, expected 127 undefined symbols to
      start at index 56715, found 133 undefined symbols starting at
      index 84

Newer Go is better Go, right?