### PR TITLE
fix: Give handler test time to process event

### DIFF
--- a/handlers/libhoney_event_handler_test.go
+++ b/handlers/libhoney_event_handler_test.go
@@ -68,7 +68,6 @@ func Test_libhoneyEventHandler_handleEvent(t *testing.T) {
 	fakeCachedK8sClient := utils.NewCachedK8sClient(fake.NewSimpleClientset(srcPod, destPod))
 	cancelableCtx, done := context.WithCancel(context.Background())
 	fakeCachedK8sClient.Start(cancelableCtx)
-	defer done()
 
 	// create event channel used to pass in events to the handler
 	eventsChannel := make(chan assemblers.HttpEvent, 1)
@@ -86,6 +85,7 @@ func Test_libhoneyEventHandler_handleEvent(t *testing.T) {
 
 	// TEST ACTION: pass in httpEvent to handler
 	eventsChannel <- httpEvent
+	time.Sleep(10 * time.Millisecond) // give the handler time to process the event
 
 	done()
 	wgTest.Wait()


### PR DESCRIPTION
## Which problem is this PR solving?
There is a timing bug in the handler test where it occasionally doesn't complete processing the event before it's closed.

## Short description of the changes
- Add a time.sleep after adding an event to the event channel to give the handler time to process it before starting shutdown
- Remove redundant `defer done()` as we intentionally call `done()` as part of our shutdown processing

## How to verify that this has the expected result
The test no longer intermittently fails.