### PR TITLE
fix: default Dockerfile build to the runnable agent stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 .PHONY: docker-build
 #: build the agent image
 docker-build:
-	docker build --target build --tag $(IMG_NAME):$(IMG_TAG) .
+	docker build --tag $(IMG_NAME):$(IMG_TAG) .
 
 .PHONY: test
 #: run unit tests


### PR DESCRIPTION
When called without a target, docker build produces an image based on the final stage in a multi-stage Dockerfile. This rearranges our Dockerfile so that the default is the runnable agent image and not the final state of compiling and testing.
