### PR TITLE
feat: set error field if HTTP status >= 400

### DIFF
--- a/handlers/libhoney_event_handler.go
+++ b/handlers/libhoney_event_handler.go
@@ -142,6 +142,15 @@ func (handler *libhoneyEventHandler) handleEvent(event assemblers.HttpEvent) {
 	// response attributes
 	if event.Response != nil {
 		ev.AddField(string(semconv.HTTPResponseStatusCodeKey), event.Response.StatusCode)
+		// We cannot quite follow the OTel spec for HTTP instrumentation and OK/Error Status.
+		// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.25.0/specification/trace/semantic_conventions/http.md#status
+		// We don't (yet?) have a way to determine the client-or-server perspective of the event,
+		// so we'll set the "error" field to the general category of the error status codes.
+		if event.Response.StatusCode >= 500 {
+			ev.AddField("error", "HTTP server error")
+		} else if event.Response.StatusCode >= 400 {
+			ev.AddField("error", "HTTP client error")
+		}
 		ev.AddField(string(semconv.HTTPResponseBodySizeKey), event.Response.ContentLength)
 
 	} else {

--- a/handlers/libhoney_event_handler_test.go
+++ b/handlers/libhoney_event_handler_test.go
@@ -113,6 +113,7 @@ func Test_libhoneyEventHandler_handleEvent(t *testing.T) {
 		"http.response.timestamp":        testReqTime.Add(3 * time.Millisecond),
 		"http.response.status_code":      418,
 		"http.response.body.size":        int64(84),
+		"error":                          "HTTP client error",
 		"duration_ms":                    int64(3),
 		"user_agent.original":            "teapot-checker/1.0",
 		"source.k8s.namespace.name":      "unit-tests",


### PR DESCRIPTION
## Short description of the changes

Distinguish between server (status >= 500) and client (500 > status >= 400) errors by noting that in the value for the error field instead of only marking error as true or false.

## How to verify that this has the expected result
