### PR TITLE
docs: update greetings example service for easier testing

### DIFF
--- a/smoke-tests/greetings.yaml
+++ b/smoke-tests/greetings.yaml
@@ -25,7 +25,7 @@ spec:
   - name: http
     port: 7777
     targetPort: 7777
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -78,7 +78,7 @@ spec:
   - name: http
     port: 9000
     targetPort: 9000
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -126,7 +126,7 @@ spec:
   - name: http
     port: 8000
     targetPort: 8000
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -177,7 +177,7 @@ spec:
   - name: http
     port: 6001
     targetPort: 6001
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/smoke-tests/greetings.yaml
+++ b/smoke-tests/greetings.yaml
@@ -205,3 +205,17 @@ spec:
           ports:
           - containerPort: 6001
             name: http
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine
+  namespace: default
+spec:
+  containers:
+  - image: alpine:latest
+    command: ["/bin/sh"]
+    args: ["-c", "apk add curl; sleep 60m"]
+    imagePullPolicy: IfNotPresent
+    name: alpine
+  restartPolicy: Always

--- a/smoke-tests/greetings.yaml
+++ b/smoke-tests/greetings.yaml
@@ -25,7 +25,7 @@ spec:
   - name: http
     port: 7777
     targetPort: 7777
-  type: ClusterIP
+  type: LoadBalancer
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## Which problem is this PR solving?

- Easier testing with greeting services

## Short description of the changes

- Use `ClusterIP` instead of `LoadBalancer` type in name, message, and year services to get better event telemetry in Honeycomb
- Add simple alpine pod with curl installed to easily shell in and curl another pod from within the cluster, without 

## How to verify that this has the expected result

You can hit the frontend endpoint from localhost in your console with `curl localhost:7777/greeting` and you can hit the frontend endpoint from the alpine image with the IP address of the pod, e.g. `curl 10.1.5.100:7777/greeting`