### PR TITLE
maint: Add RequestId and Packet Count to metatelemetry

### DIFF
--- a/assemblers/http_event.go
+++ b/assemblers/http_event.go
@@ -6,12 +6,14 @@ import (
 )
 
 type HttpEvent struct {
-	StreamIdent       string
-	RequestId         int64
-	Request           *http.Request
-	Response          *http.Response
-	RequestTimestamp  time.Time
-	ResponseTimestamp time.Time
-	SrcIp             string
-	DstIp             string
+	StreamIdent         string
+	RequestId           int64
+	Request             *http.Request
+	Response            *http.Response
+	RequestTimestamp    time.Time
+	ResponseTimestamp   time.Time
+	RequestPacketCount  int
+	ResponsePacketCount int
+	SrcIp               string
+	DstIp               string
 }

--- a/assemblers/http_matcher.go
+++ b/assemblers/http_matcher.go
@@ -11,10 +11,12 @@ type httpMatcher struct {
 }
 
 type entry struct {
-	request           *http.Request
-	requestTimestamp  time.Time
-	response          *http.Response
-	responseTimestamp time.Time
+	request             *http.Request
+	requestTimestamp    time.Time
+	response            *http.Response
+	responseTimestamp   time.Time
+	requestPacketCount  int
+	responsePacketCount int
 }
 
 func newRequestResponseMatcher() *httpMatcher {
@@ -30,10 +32,11 @@ func newRequestResponseMatcher() *httpMatcher {
 //
 // If the response hasn't been seen yet,
 // stores the Request for later lookup and returns match as nil and matchFound will be false.
-func (m *httpMatcher) GetOrStoreRequest(key int64, timestamp time.Time, request *http.Request) (match *entry, matchFound bool) {
+func (m *httpMatcher) GetOrStoreRequest(key int64, timestamp time.Time, request *http.Request, packetCount int) (match *entry, matchFound bool) {
 	e := &entry{
-		request:          request,
-		requestTimestamp: timestamp,
+		request:            request,
+		requestTimestamp:   timestamp,
+		requestPacketCount: packetCount,
 	}
 
 	if v, matchFound := m.entries.LoadOrStore(key, e); matchFound {
@@ -54,10 +57,11 @@ func (m *httpMatcher) GetOrStoreRequest(key int64, timestamp time.Time, request 
 //
 // If the request hasn't been seen yet,
 // stores the Response for later lookup and returns match as nil and matchFound will be false.
-func (m *httpMatcher) GetOrStoreResponse(key int64, timestamp time.Time, response *http.Response) (match *entry, matchFound bool) {
+func (m *httpMatcher) GetOrStoreResponse(key int64, timestamp time.Time, response *http.Response, packetCount int) (match *entry, matchFound bool) {
 	e := &entry{
-		response:          response,
-		responseTimestamp: timestamp,
+		response:            response,
+		responseTimestamp:   timestamp,
+		responsePacketCount: packetCount,
 	}
 
 	if v, matchFound := m.entries.LoadOrStore(key, e); matchFound {

--- a/assemblers/tcp_reader.go
+++ b/assemblers/tcp_reader.go
@@ -75,7 +75,7 @@ func (reader *tcpReader) reassembledSG(sg reassembly.ScatterGather, ac reassembl
 			req.Body.Close()
 		}
 
-		if entry, matchFound := reader.matcher.GetOrStoreRequest(requestId, ctx.CaptureInfo.Timestamp, req); matchFound {
+		if entry, matchFound := reader.matcher.GetOrStoreRequest(requestId, ctx.CaptureInfo.Timestamp, req, sg.Stats().Packets); matchFound {
 			// we have a match, process complete request/response pair
 			reader.processEvent(requestId, entry)
 		}
@@ -104,7 +104,7 @@ func (reader *tcpReader) reassembledSG(sg reassembly.ScatterGather, ac reassembl
 			res.Body.Close()
 		}
 
-		if entry, matchFound := reader.matcher.GetOrStoreResponse(requestId, ctx.CaptureInfo.Timestamp, res); matchFound {
+		if entry, matchFound := reader.matcher.GetOrStoreResponse(requestId, ctx.CaptureInfo.Timestamp, res, sg.Stats().Packets); matchFound {
 			// we have a match, process complete request/response pair
 			reader.processEvent(requestId, entry)
 		}
@@ -113,13 +113,15 @@ func (reader *tcpReader) reassembledSG(sg reassembly.ScatterGather, ac reassembl
 
 func (reader *tcpReader) processEvent(requestId int64, entry *entry) {
 	reader.events <- HttpEvent{
-		StreamIdent:       reader.streamIdent,
-		RequestId:         requestId,
-		Request:           entry.request,
-		Response:          entry.response,
-		RequestTimestamp:  entry.requestTimestamp,
-		ResponseTimestamp: entry.responseTimestamp,
-		SrcIp:             reader.srcIp,
-		DstIp:             reader.dstIp,
+		StreamIdent:         reader.streamIdent,
+		RequestId:           requestId,
+		Request:             entry.request,
+		Response:            entry.response,
+		RequestTimestamp:    entry.requestTimestamp,
+		ResponseTimestamp:   entry.responseTimestamp,
+		RequestPacketCount:  entry.requestPacketCount,
+		ResponsePacketCount: entry.responsePacketCount,
+		SrcIp:               reader.srcIp,
+		DstIp:               reader.dstIp,
 	}
 }

--- a/handlers/libhoney_event_handler.go
+++ b/handlers/libhoney_event_handler.go
@@ -121,6 +121,8 @@ func (handler *libhoneyEventHandler) handleEvent(event assemblers.HttpEvent) {
 	ev.AddField("meta.httpEvent_response_handled_latency_ms", time.Since(event.ResponseTimestamp).Milliseconds())
 	ev.AddField("meta.stream.ident", event.StreamIdent)
 	ev.AddField("meta.seqack", event.RequestId)
+	ev.AddField("meta.request.packet_count", event.RequestPacketCount)
+	ev.AddField("meta.response.packet_count", event.ResponsePacketCount)
 	ev.AddField("duration_ms", eventDuration.Milliseconds())
 	ev.AddField("http.request.timestamp", event.RequestTimestamp)
 	ev.AddField("http.response.timestamp", event.ResponseTimestamp)

--- a/handlers/libhoney_event_handler.go
+++ b/handlers/libhoney_event_handler.go
@@ -99,6 +99,7 @@ func (handler *libhoneyEventHandler) handleEvent(event assemblers.HttpEvent) {
 			Int64("request_id", event.RequestId).
 			Msg("Request timestamp is zero")
 		ev.AddField("http.request.timestamp_missing", true)
+		log.Info().Int64("request_request_id", event.RequestId)
 		event.RequestTimestamp = time.Now()
 	}
 	if event.ResponseTimestamp.IsZero() {
@@ -107,9 +108,11 @@ func (handler *libhoneyEventHandler) handleEvent(event assemblers.HttpEvent) {
 			Int64("request_id", event.RequestId).
 			Msg("Response timestamp is zero")
 		ev.AddField("http.response.timestamp_missing", true)
+		log.Info().Int64("response_request_id", event.RequestId)
 		event.ResponseTimestamp = time.Now()
 	}
 	eventDuration := event.ResponseTimestamp.Sub(event.RequestTimestamp)
+	log.Info().Int64("request_id", event.RequestId)
 
 	// common attributes
 	ev.Timestamp = event.RequestTimestamp
@@ -117,6 +120,7 @@ func (handler *libhoneyEventHandler) handleEvent(event assemblers.HttpEvent) {
 	ev.AddField("meta.httpEvent_request_handled_latency_ms", time.Since(event.RequestTimestamp).Milliseconds())
 	ev.AddField("meta.httpEvent_response_handled_latency_ms", time.Since(event.ResponseTimestamp).Milliseconds())
 	ev.AddField("meta.stream.ident", event.StreamIdent)
+	ev.AddField("meta.seqack", event.RequestId)
 	ev.AddField("duration_ms", eventDuration.Milliseconds())
 	ev.AddField("http.request.timestamp", event.RequestTimestamp)
 	ev.AddField("http.response.timestamp", event.ResponseTimestamp)


### PR DESCRIPTION
## Which problem is this PR solving?

In service to #209, add more meta telemetry for easier data validation
- #209 

## Short description of the changes

- Add `meta.seqack` to events emitted by the agent. The SEQ corresponds to ACK of the HTTP request, and ACK corresponds to SEQ of the HTTP response.
- Add `meta.request.packet_count`, and `meta.response.packet_count` to events emitted by the agent.

Including these in telemetry may make it easier to validate proper matching of request/response pairs.

## How to verify that this has the expected result

Events in Honeycomb contain these fields