### PR TITLE
fix: skip key validation if endpoint is different

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -187,6 +187,11 @@ func (c *Config) Validate() error {
 	if c.APIKey == "" {
 		e = append(e, &MissingAPIKeyError{})
 	}
+	// if endpoint doesn't match default, don't validate API key
+	// this is primarily used for testing so no config options are provided
+	if c.Endpoint != "https://api.honeycomb.io" {
+		return nil
+	}
 	libhoneyConfig := libhoney.Config{APIKey: c.APIKey}
 	if _, err := libhoney.VerifyAPIKey(libhoneyConfig); err != nil {
 		e = append(e, &InvalidAPIKeyError{})

--- a/main.go
+++ b/main.go
@@ -22,9 +22,6 @@ const Version string = "0.0.19-alpha"
 
 func main() {
 	config := config.NewConfig()
-	if err := config.Validate(); err != nil {
-		log.Fatal().Err(err).Msg("Config validation failed")
-	}
 
 	// setup logging first
 	// TODO: move to utils package?
@@ -37,6 +34,13 @@ func main() {
 		Str("dataset", config.Dataset).
 		Str("stats_dataset", config.StatsDataset).
 		Msg("Starting Honeycomb Network Agent")
+
+	// validate config after logging existing config values
+	// to make it easier to troubleshoot
+	if err := config.Validate(); err != nil {
+		log.Fatal().Err(err).Msg("Config validation failed")
+	}
+
 	if config.Debug {
 		log.Info().
 			Str("debug_address", config.DebugAddress).

--- a/smoke-tests/deployment.yaml
+++ b/smoke-tests/deployment.yaml
@@ -106,6 +106,9 @@ spec:
                 secretKeyRef:
                   name: honeycomb
                   key: api-key
+            ## uncomment this to change the endpoint for events (uncommon)
+            # - name: HONEYCOMB_API_ENDPOINT
+            #   value: $HONEYCOMB_API_ENDPOINT
             ## uncomment this to set the destination dataset for events
             # - name: HONEYCOMB_DATASET
             #   value: $HONEYCOMB_DATASET


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #264 

## Short description of the changes

- Check endpoint and if it differs from our default, skip the api key validation
- Move the Config Validate below the logging of config values; that way, if there is something wrong, the config values are printed out first for easier troubleshooting if it fails.

I'd considered some refactoring to pull out defaults and use a variable instead of hardcoding here, but wasn't sure it was worth the extra cleanup for this rare use case.

## How to verify that this has the expected result

Set an incorrect API Key. With no change to endpoint, or endpoint set to `"https://api.honeycomb.io"`, agent pod should fail to start because of invalid key - and should log the config options followed by the fatal error. With a different endpoint, agent should start with no failure.