### PR TITLE
maint: even smaller image size with no cached APT repo lists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN make test
 FROM ubuntu:22.04
 RUN apt-get update -yq && \
     apt-get install -yq --no-install-recommends ca-certificates libpcap-dev && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 COPY --from=base /src/hny-network-agent /bin/hny-network-agent
 ENTRYPOINT [ "/bin/hny-network-agent" ]


### PR DESCRIPTION
## Which problem is this PR solving?

- More in service to #128 

## Short description of the changes

Remove the cached repository lists to reduce the image size by another ~40 MB.

247MB -> 206MB :: ~20% smaller!
