### PR TITLE
maint: include k8s vars in quickstart and add resource limits to test manifest

### DIFF
--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -49,10 +49,6 @@ spec:
         - name: hny-network-agent
           image: ghcr.io/honeycombio/network-agent:latest
           imagePullPolicy: IfNotPresent
-          resources:
-            limits:
-              cpu: 750m
-              memory: 2Gi
           env:
           # https://kubernetes.io/docs/concepts/workloads/pods/downward-api/
           # these are used to get kubernetes metadata attached to events

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -49,7 +49,10 @@ spec:
         - name: hny-network-agent
           image: ghcr.io/honeycombio/network-agent:latest
           imagePullPolicy: IfNotPresent
-          env:
+          resources:
+            limits:
+              cpu: 750m
+              memory: 2Gi
             - name: HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -53,6 +53,29 @@ spec:
             limits:
               cpu: 750m
               memory: 2Gi
+          env:
+          # https://kubernetes.io/docs/concepts/workloads/pods/downward-api/
+          # these are used to get kubernetes metadata attached to events
+            - name: AGENT_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: AGENT_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: AGENT_SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: AGENT_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: AGENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/smoke-tests/deployment.yaml
+++ b/smoke-tests/deployment.yaml
@@ -79,6 +79,11 @@ spec:
           # uncomment this to enable profiling listener on port 6060
           # ports:
           #   - containerPort: 6060
+          # uncomment this to set resource limits for a container
+          # resources:
+          #   limits:
+          #     cpu: 750m
+          #     memory: 2Gi
           env:
           # https://kubernetes.io/docs/concepts/workloads/pods/downward-api/
             - name: AGENT_NODE_IP

--- a/smoke-tests/deployment.yaml
+++ b/smoke-tests/deployment.yaml
@@ -86,6 +86,7 @@ spec:
           #     memory: 2Gi
           env:
           # https://kubernetes.io/docs/concepts/workloads/pods/downward-api/
+          # these are used to get kubernetes metadata attached to events
             - name: AGENT_NODE_IP
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Which problem is this PR solving?

- In service to #273

## Short description of the changes

- add resource limits to smoke test deployment manifest
- add missed variables to quickstart example for k8s metadata
- add note for why the k8s variables are used

## How to verify that this has the expected result

Quickstart includes k8s metadata; smoke test deployment can have limits uncommented and work as expected

These values may need to be adjusted based on traffic but this starter kept under limit running a load test of 8000 users spawning at 100/sec.