### PR TITLE
feat: capture more types of HTTP requests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -171,6 +171,11 @@ func buildBpfFilter() string {
 		"tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x504F5354", // 'POST'
 		"tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x50555420", // 'PUT '
 		"tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x44454C45", // 'DELE'TE
+		"tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x48454144", // 'HEAD'
+		"tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x4F505449", // 'OPTI'ONS
+		"tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x50415443", // 'PATC'H
+		"tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x54524143", // 'TRAC'E
+		"tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x434F4E4E", // 'CONN'ECT
 		// HTTP 1.1 is the response start string
 		"tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x48545450", // 'HTTP' 1.1
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -156,31 +157,51 @@ func (c *Config) GetMaskedAPIKey() string {
 	return strings.Repeat("*", len(c.APIKey)-4) + c.APIKey[len(c.APIKey)-4:]
 }
 
-// buildBpfFilter builds a BPF filter to only capture HTTP traffic
-// TODO: Move somewhere more appropriate
-func buildBpfFilter() string {
-	// Add filters to only capture common HTTP methods
-	// TODO "not host me", // how do we get our current IP?
-	// reference links:
-	// https://www.middlewareinventory.com/blog/tcpdump-capture-http-get-post-requests-apache-weblogic-websphere/
-	// https://www.middlewareinventory.com/ascii-table/
-	// tcp[((tcp[12:1] & 0xf0) >> 2):<num> means skip the ip & tcp headers, then get the next <num> bytes and match hex
-	// bpf insists that we must use 1, 2, or 4 bytes
-	matchFirstFourBytesTo := "tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x"
+// HTTP Payloads start with one of these strings.
+// Four characters are given because this feeds into a BPF filter
+// and BPF really wants to match on 1, 2, or 4 byte boundaries.
+var httpPayloadsStartWith = []string{
+	// HTTP Methods are request start
+	"GET ", "POST", "PUT ", "DELE", "HEAD", "OPTI", "PATC", "TRAC", "CONN",
+	// HTTP/1.x is the response start
+	"HTTP",
+}
 
-	filters := []string{
-		// HTTP Methods are request start strings
-		matchFirstFourBytesTo + hex.EncodeToString([]byte("GET ")),
-		matchFirstFourBytesTo + hex.EncodeToString([]byte("POST")),
-		matchFirstFourBytesTo + hex.EncodeToString([]byte("PUT ")),
-		matchFirstFourBytesTo + hex.EncodeToString([]byte("DELE")),
-		matchFirstFourBytesTo + hex.EncodeToString([]byte("HEAD")),
-		matchFirstFourBytesTo + hex.EncodeToString([]byte("OPTI")),
-		matchFirstFourBytesTo + hex.EncodeToString([]byte("PATC")),
-		matchFirstFourBytesTo + hex.EncodeToString([]byte("TRAC")),
-		matchFirstFourBytesTo + hex.EncodeToString([]byte("CONN")),
-		// HTTP 1.1 is the response start string
-		matchFirstFourBytesTo + hex.EncodeToString([]byte("HTTP")),
+// pcapComputeTcpHeaderOffset is a [pcap filter] sub-string for pcap
+// to figure out the TCP header length for a given packet.
+//
+// We use this to find the start of the TCP payload. See a [breakdown of this filter].
+//
+// [pcap filter]: https://www.tcpdump.org/manpages/pcap-filter.7.html
+// [breakdown of this filter]: https://security.stackexchange.com/a/121013
+const pcapComputeTcpHeaderOffset = "((tcp[12:1] & 0xf0) >> 2)"
+
+// pcapTcpPayloadStartsWith returns a [pcap filter] string.
+// The filter matches a given string against the first bytes of a TCP payload.
+// Deeper details this filter can be found at [capturing HTTP requests with tcpdump].
+//
+// [pcap filter]: https://www.tcpdump.org/manpages/pcap-filter.7.html
+// [capturing HTTP requests with tcpdump]: https://www.middlewareinventory.com/blog/tcpdump-capture-http-get-post-requests-apache-weblogic-websphere/
+func pcapTcpPayloadStartsWith(s string) (filter string, err error) {
+	if len(s) != 4 {
+		return "", fmt.Errorf("pcapTcpPayloadStartsWith: string must be 4 characters long, got %d", len(s))
+	}
+
+	// tcp[O:N] - from TCP traffic, get the N bytes that appear after the offset O
+	return fmt.Sprintf("tcp[%s:4] = 0x%s", pcapComputeTcpHeaderOffset, hex.EncodeToString([]byte(s))), nil
+}
+
+// buildBpfFilter builds a BPF filter to only capture HTTP traffic
+func buildBpfFilter() string {
+	// TODO: Move this logic somewhere more HTTP-flavored
+	// TODO "not host me", // how do we get our current IP?
+
+	filters := []string{}
+	for _, method := range httpPayloadsStartWith {
+		filter, err := pcapTcpPayloadStartsWith(method)
+		if err == nil {
+			filters = append(filters, filter)
+		}
 	}
 	return strings.Join(filters, " or ")
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,10 +1,9 @@
-package config_test
+package config
 
 import (
 	"os"
 	"testing"
 
-	"github.com/honeycombio/honeycomb-network-agent/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,7 +37,7 @@ func TestAPIMask(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			config := config.Config{
+			config := Config{
 				APIKey: tc.apiKey,
 			}
 
@@ -64,7 +63,7 @@ func TestEnvVars(t *testing.T) {
 	t.Setenv("ADDITIONAL_ATTRIBUTES", "key1=value1,key2=value2")
 	t.Setenv("INCLUDE_REQUEST_URL", "true")
 
-	config := config.NewConfig()
+	config := NewConfig()
 	assert.Equal(t, "1234567890123456789012", config.APIKey)
 	assert.Equal(t, "https://api.example.com", config.Endpoint)
 	assert.Equal(t, "test-dataset", config.Dataset)
@@ -88,7 +87,7 @@ func TestEnvVarsDefault(t *testing.T) {
 	// all the env vars in an array
 	os.Clearenv()
 
-	config := config.NewConfig()
+	config := NewConfig()
 	assert.Equal(t, "", config.APIKey)
 	assert.Equal(t, "https://api.honeycomb.io", config.Endpoint)
 	assert.Equal(t, "hny-network-agent", config.Dataset)


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #272 

## Short description of the changes

- Extend list of supported HTTP methods in the bpf filter used to capture network activity to include HEAD, OPTIONS, PATCH, TRACE and CONNECT
- Breaks up the components that make up the capture filter. Lots of words written about what the pieces do.
  - This is ripe for extraction into an HTTP-flavored subpackage.
- Tests for the filter generator

## How to verify that this has the expected result

More HTTP methods will be captured and have events created from. 