### PR TITLE
maint: Tidy start-up logging

### DIFF
--- a/assemblers/tcp_assembler.go
+++ b/assemblers/tcp_assembler.go
@@ -101,7 +101,6 @@ func NewTcpAssembler(config config.Config, eventsChan chan Event) tcpAssembler {
 func (h *tcpAssembler) Start(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	log.Info().Msg("Starting TCP assembler")
 	// Tick on the tightest loop. The flush timeout is the shorter of the two timeouts using this ticker.
 	// Tick even more frequently than the flush interval (4 is somewhat arbitrary)
 	flushCloseTicker := time.NewTicker(h.config.StreamFlushTimeout / 4)

--- a/assemblers/tcp_assembler.go
+++ b/assemblers/tcp_assembler.go
@@ -222,7 +222,7 @@ func (a *tcpAssembler) logAssemblerStats() {
 }
 
 func newPcapPacketSource(config config.Config) (*gopacket.PacketSource, error) {
-	log.Info().
+	log.Debug().
 		Str("interface", config.Interface).
 		Int("snaplen", config.Snaplen).
 		Bool("promiscuous", config.Promiscuous).

--- a/debug/debug_service.go
+++ b/debug/debug_service.go
@@ -64,10 +64,6 @@ func (s *DebugService) Start() error {
 		if configAddr != "" {
 			host, portStr, _ := net.SplitHostPort(configAddr)
 			addr := net.JoinHostPort(host, portStr)
-			log.Info().
-				Str("addr", addr).
-				Msg("Debug service listening")
-
 			err := http.ListenAndServe(addr, s.mux)
 			log.Debug().
 				Err(err).


### PR DESCRIPTION
## Which problem is this PR solving?
There are a number of start-up messages that should be at debug level instead of Info to get keep the log clear. This PR tidies up some logging. 

## Short description of the changes
- Remove unneccary log entries in assembler and debug service
- Change pcap config log to debug

## How to verify that this has the expected result
The log entries when starting the agent are a little cleaner.