### PR TITLE
maint: update smoke test deployment for new env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ kubectl create secret generic honeycomb --from-literal=api-key=$HONEYCOMB_API_KE
 The network agent can be configured using the following environment variables.
 
 | Environment Variable      | Description                                                                              | Default                    | Required? |
-|---------------------------|------------------------------------------------------------------------------------------|----------------------------|-----------|
+| ------------------------- | ---------------------------------------------------------------------------------------- | -------------------------- | --------- |
 | `HONEYCOMB_API_KEY`       | The Honeycomb API key used when sending events                                           | `` (empty)                 | **Yes**   |
 | `HONEYCOMB_API_ENDPOINT`  | The endpoint to send events to                                                           | `https://api.honeycomb.io` | No        |
 | `HONEYCOMB_DATASET`       | Dataset where network events are stored                                                  | `hny-network-agent`        | No        |
@@ -58,7 +58,7 @@ The network agent can be configured using the following environment variables.
 | `INCLUDE_REQUEST_URL`     | Include the request URL in events                                                        | `true`                     | No        |
 | `HTTP_HEADERS`            | Case-sensitive, comma separated list of headers to be recorded from requests/responses†  | `User-Agent`               | No        |
 
-†: When providing an overide of a list of values, you must provide all values including any defaults.
+†: When providing an override of a list of values, you must provide all values including any defaults.
 
 ### Run
 
@@ -73,7 +73,7 @@ Alternative options for configuration and running can be found in [Deploying the
 ## Supported Platforms
 
 | Platform                                                             | Supported                           |
-|----------------------------------------------------------------------|-------------------------------------|
+| -------------------------------------------------------------------- | ----------------------------------- |
 | [AKS](https://azure.microsoft.com/en-gb/products/kubernetes-service) | Supported ✅                         |
 | [EKS](https://aws.amazon.com/eks/)                                   | Self-managed hosts ✅ <br> Fargate ❌ |
 | [GKE](https://cloud.google.com/kubernetes-engine)                    | Standard cluster ✅ <br> AutoPilot ❌ |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The network agent can be configured using the following environment variables.
 | `LOG_LEVEL`               | The log level to use when printing logs to console                                       | `INFO`                     | No        |
 | `DEBUG`                   | Runs the agent in debug mode including enabling a profiling endpoint using Debug Address | `false`                    | No        |
 | `DEBUG_ADDRESS`           | The endpoint to listen to when running the profile endpoint                              | `localhost:6060`           | No        |
+| `ADDITIONAL_ATTRIBUTES`   | Extra attributes to include on all events                                                | `` (empty)                 | No        |
+| `INCLUDE_REQUEST_URL`     | Include the request URL in events                                                        | `true`                     | No        |
 | `HTTP_HEADERS`            | Case-sensitive, comma separated list of headers to be recorded from requests/responses†  | `User-Agent`               | No        |
 
 †: When providing an overide of a list of values, you must provide all values including any defaults.

--- a/smoke-tests/deployment.yaml
+++ b/smoke-tests/deployment.yaml
@@ -135,7 +135,7 @@ spec:
             #   value: "key1=value1,key2=value2"
             ## uncomment this to configure a list of HTTP headers to be recorded from requests/responses.
             # - name: HTTP_HEADERS
-            #   value: "User-Agent,Header-1,header-2"
+            #   value: "User-Agent,X-Custom-Header"
             ## uncomment this to disable including the request URL in events
             # - name: INCLUDE_REQUEST_URL
             #   value: "false"

--- a/smoke-tests/deployment.yaml
+++ b/smoke-tests/deployment.yaml
@@ -133,9 +133,12 @@ spec:
             ## uncomment this to add extra attributes to all events
             # - name: ADDITIONAL_ATTRIBUTES
             #   value: "key1=value1,key2=value2"
-            ## uncomment this to enable including the request URL in events
+            ## uncomment this to configure a list of HTTP headers to be recorded from requests/responses.
+            # - name: HTTP_HEADERS
+            #   value: "User-Agent,Header-1,header-2"
+            ## uncomment this to disable including the request URL in events
             # - name: INCLUDE_REQUEST_URL
-            #   value: "true"
+            #   value: "false"
           securityContext:
             capabilities:
               add:


### PR DESCRIPTION
## Which problem is this PR solving?

- request url is enabled by default, example should disable
- http_headers are options now

## Short description of the changes

- update smoke test deployment with new environment variables
- update the config table in the readme with the new environment variables
- some formatting cleanup from my editor
