### PR TITLE
fix: add headers to honeycomb event

### DIFF
--- a/handlers/libhoney_event_handler.go
+++ b/handlers/libhoney_event_handler.go
@@ -180,6 +180,9 @@ func (handler *libhoneyEventHandler) addHttpFields(ev *libhoney.Event, event *as
 				ev.AddField(string(semconv.URLPathKey), url.Path)
 			}
 		}
+		// by this point, we've already extracted headers based on HTTP_HEADERS list
+		// so we can safely add the headers to the event
+		ev.AddField("http.request.headers", event.Request().Header)
 	} else {
 		ev.AddField("name", "HTTP")
 		ev.AddField("http.request.missing", "no request on this event")
@@ -198,6 +201,9 @@ func (handler *libhoneyEventHandler) addHttpFields(ev *libhoney.Event, event *as
 			ev.AddField("error", "HTTP client error")
 		}
 		ev.AddField(string(semconv.HTTPResponseBodySizeKey), event.Response().ContentLength)
+		// by this point, we've already extracted headers based on HTTP_HEADERS list
+		// so we can safely add the headers to the event
+		ev.AddField("http.response.headers", event.Response().Header)
 	} else {
 		ev.AddField("http.response.missing", "no response on this event")
 	}

--- a/handlers/libhoney_event_handler_test.go
+++ b/handlers/libhoney_event_handler_test.go
@@ -101,6 +101,8 @@ func Test_libhoneyEventHandler_handleEvent(t *testing.T) {
 		"http.request.method":            "GET",
 		"url.path":                       "/check",
 		"http.request.body.size":         int64(42),
+		"http.request.headers":           http.Header{"User-Agent": []string{"teapot-checker/1.0"}, "Connection": []string{"keep-alive"}},
+		"http.response.headers":          http.Header{"Content-Type": []string{"text/plain; charset=utf-8"}, "X-Custom-Header": []string{"tea-party"}},
 		"http.request.timestamp":         requestTimestamp,
 		"http.response.timestamp":        responseTimestamp,
 		"http.response.status_code":      418,
@@ -248,6 +250,8 @@ func Test_libhoneyEventHandler_handleEvent_routed_to_service(t *testing.T) {
 		"http.request.method":            "GET",
 		"url.path":                       "/check",
 		"http.request.body.size":         int64(42),
+		"http.request.headers":           http.Header{"User-Agent": []string{"teapot-checker/1.0"}, "Connection": []string{"keep-alive"}},
+		"http.response.headers":          http.Header{"Content-Type": []string{"text/plain; charset=utf-8"}, "X-Custom-Header": []string{"tea-party"}},
 		"http.request.timestamp":         requestTimestamp,
 		"http.response.timestamp":        responseTimestamp,
 		"http.response.status_code":      418,
@@ -379,11 +383,12 @@ func createTestHttpEvent(requestTimestamp, responseTimestamp time.Time) *assembl
 			Method:        "GET",
 			RequestURI:    "/check?teapot=true",
 			ContentLength: 42,
-			Header:        http.Header{"User-Agent": []string{"teapot-checker/1.0"}},
+			Header:        http.Header{"User-Agent": []string{"teapot-checker/1.0"}, "Connection": []string{"keep-alive"}},
 		},
 		&http.Response{
 			StatusCode:    418,
 			ContentLength: 84,
+			Header:        http.Header{"Content-Type": []string{"text/plain; charset=utf-8"}, "X-Custom-Header": []string{"tea-party"}},
 		},
 	)
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #288 

## Short description of the changes

- add fields for `http.request.headers` and `http.response.headers` and accompanying unit tests. #277 added all the logic for configuring the `HTTP_HEADERS` to be extracted, and this PR adds the headers to the actual event to be sent to Honeycomb.

This is the smaller implementation mentioned in the issue. We could (/should?) have individual attributes for each key, but I figured this could be a faster fix to start since we've already published with the expectation of HTTP_HEADERS working.

## How to verify that this has the expected result

Run the agent with something like the example greeting service and see the attributes in Honeycomb.

The default captures just the User-Agent:

- `http.request.headers`
  - example: `"{\"User-Agent\":[\"Go-http-client/1.1\"]}"`
- `http.response.headers`
  - example: `"{}"`

If for example the list includes `"User-Agent,Accept-Encoding,Content-Length,Content-Type"`, the result looks like this:

- `http.request.headers`
  - example: `"{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"Go-http-client/1.1\"]}"`
- `http.response.headers`
  - example: `"{\"Content-Length\":[\"12\"],\"Content-Type\":[\"text/plain; charset=utf-8\"]}"`