### PR TITLE
Follow OTel semantic conventions when converting headers

### DIFF
--- a/handlers/otel_handler_test.go
+++ b/handlers/otel_handler_test.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/honeycombio/honeycomb-network-agent/assemblers"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// test that headerToAttributes correctly sets attributes from headers
+func TestHeaderToAttributes(t *testing.T) {
+	requestTimestamp := time.Now()
+	responseTimestamp := requestTimestamp.Add(3 * time.Millisecond)
+	event := createTestOtelEvent(requestTimestamp, responseTimestamp)
+
+	reqAttrs := (headerToAttributes(true, event.Request().Header))
+
+	expectedReqAttrs := []attribute.KeyValue{
+		attribute.String("http.request.header.user_agent", "teapot-checker/1.0"),
+		attribute.String("http.request.header.connection", "keep-alive"),
+	}
+
+	assert.Equal(t, expectedReqAttrs, reqAttrs)
+
+	resAttrs := (headerToAttributes(false, event.Response().Header))
+	expectedResAttrs := []attribute.KeyValue{
+		attribute.String("http.response.header.content_type", "text/plain; charset=utf-8"),
+		attribute.String("http.response.header.x_custom_header", "tea-party"),
+	}
+	assert.Equal(t, expectedResAttrs, resAttrs)
+}
+
+func createTestOtelEvent(requestTimestamp, responseTimestamp time.Time) *assemblers.HttpEvent {
+	return assemblers.NewHttpEvent(
+		"c->s:1->2",
+		0,
+		requestTimestamp,
+		responseTimestamp,
+		2,
+		3,
+		"1.2.3.4",
+		"5.6.7.8",
+		&http.Request{
+			Method:        "GET",
+			RequestURI:    "/check?teapot=true",
+			ContentLength: 42,
+			Header:        http.Header{"User-Agent": []string{"teapot-checker/1.0"}, "Connection": []string{"keep-alive"}},
+		},
+		&http.Response{
+			StatusCode:    418,
+			ContentLength: 84,
+			Header:        http.Header{"Content-Type": []string{"text/plain; charset=utf-8"}, "X-Custom-Header": []string{"tea-party"}},
+		},
+	)
+}

--- a/smoke-tests/deployment.yaml
+++ b/smoke-tests/deployment.yaml
@@ -112,10 +112,14 @@ spec:
                 secretKeyRef:
                   name: honeycomb
                   key: api-key
-            ## uncomment this to change the endpoint for events (uncommon)
+            ## uncomment this to change the endpoint for events
             # - name: HONEYCOMB_API_ENDPOINT
             #   value: $HONEYCOMB_API_ENDPOINT
+            ## uncomment this to send to insecure endpoint like collector
+            # - name: OTEL_EXPORTER_OTLP_INSECURE
+            #   value: "true"
             ## uncomment this to set the destination dataset for events
+            ## this will represent service.name in honeycomb when using otel
             # - name: HONEYCOMB_DATASET
             #   value: $HONEYCOMB_DATASET
             ## uncomment this to set the destination dataset for agent performance stats
@@ -130,10 +134,14 @@ spec:
             ## uncomment this to enable profiling
             # - name: DEBUG
             #   value: "$DEBUG"
-            ## uncomment this to add extra attributes to all events
+            ## uncomment this to add extra attributes to all events when using libhoney handler
             # - name: ADDITIONAL_ATTRIBUTES
-            #   value: "key1=value1,key2=value2"
+            #   value: "handler=libhoney,environment=dev"
+            ## uncomment this to add extra attributes to all events when using otel handler
+            # - name: OTEL_RESOURCE_ATTRIBUTES
+            #   value: "handler=otel,environment=dev"
             ## uncomment this to configure a list of HTTP headers to be recorded from requests/responses.
+            ## this will show as http.request.header.user_agent and http.response.header.x_custom_header
             # - name: HTTP_HEADERS
             #   value: "User-Agent,X-Custom-Header"
             ## uncomment this to disable including the request URL in events


### PR DESCRIPTION
## Which problem is this PR solving?
More closely follows sem conv when handing headers in the otel handler. 
