### PR TITLE
maint: Add otel dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,6 @@ updates:
       k8s-dependencies:
         patterns:
           - "k8s.io/*"
+      otel-dependencies:
+        patterns:
+          - "go.opentelemetry.io/otel/*"


### PR DESCRIPTION
## Which problem is this PR solving?
Adds a dependency group to dependabot config so related packages are updated together. 

## Short description of the changes
- Add groups for otel to dependabot config

## How to verify that this has the expected result
Dependabot will group OTel packages into PRs.