### PR TITLE
docs: Document expected behaviour for event creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Events include network level information such as source & destination IPs and po
 ![design diagram](./agent_design.png)
 
 The agent generates events per Kubernetes host by inspecting network traffic, in the perspective of either the receiving or sending process.
-This results in events being generated in the following 3 scenarios:
+This results in events being generated in the following scenarios:
 - External to pod (cluster ingress)
 - Pod to pod
 - Pod to Service

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The agent generates events per Kubernetes host by inspecting network traffic, in
 This results in events being generated in the following 3 scenarios:
 - External to pod (cluster ingress)
 - Pod to pod
+- Pod to Service
 - Pod to external (cluster egress)
 
 **NOTE**: For pod-to-pod interactions when each pod is on seperate Kubernetes nodes, two events will be created.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Events include network level information such as source & destination IPs and po
 
 ![design diagram](./agent_design.png)
 
+The agent generates events per Kubernetes host by inspecting network traffic, in the perspective of either the receiving or sending process.
+This results in events being generated in the following 3 scenarios:
+- External to pod (cluster ingress)
+- Pod to pod
+- Pod to external (cluster egress)
+
+**NOTE**: For pod-to-pod interactions when each pod is on seperate Kubernetes nodes, two events will be created.
+
 ## Getting Started (Quickstart)
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Events include network level information such as source & destination IPs and po
 ![design diagram](./agent_design.png)
 
 The agent generates events per Kubernetes host by inspecting network traffic, in the perspective of either the receiving or sending process.
-This results in events being generated in the following scenarios:
+Amongst the scenarios events are genreated for:
 - External to pod (cluster ingress)
 - Pod to pod
 - Pod to Service

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Events include network level information such as source & destination IPs and po
 ![design diagram](./agent_design.png)
 
 The agent generates events per Kubernetes host by inspecting network traffic, in the perspective of either the receiving or sending process.
-Amongst the scenarios events are genreated for:
-- External to pod (cluster ingress)
-- Pod to pod
-- Pod to Service
-- Pod to external (cluster egress)
+Amongst the scenarios events are generated for:
+- external to pod (cluster ingress)
+- pod to service
+- pod to pod
+- pod to external (cluster egress)
 
-**NOTE**: For pod-to-pod interactions when each pod is on seperate Kubernetes nodes, two events will be created.
+**NOTE**: For pod-to-pod interactions when each pod is on separate Kubernetes nodes, two events will be created.
 
 ## Getting Started (Quickstart)
 


### PR DESCRIPTION
## Which problem is this PR solving?
Adds documentation on expected behaviour for generating events for different types of communication (eg cluster ingress/egress and pod-to-pod). 

- Closes #115 

## Short description of the changes
- Adds a section to the project's README to describe expected behaviour for event generation
- Adds note after the above section to indicate expected behaviour for pod-to-pod events

## How to verify that this has the expected result
The project README has docs on expected event generation behaviour. 