### PR TITLE
feat: Make OTel handler default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -152,7 +152,7 @@ func NewConfig() Config {
 		AdditionalAttributes:          utils.LookupEnvAsStringMap("ADDITIONAL_ATTRIBUTES"),
 		IncludeRequestURL:             utils.LookupEnvOrBool("INCLUDE_REQUEST_URL", true),
 		HTTPHeadersToExtract:          getHTTPHeadersToExtract(),
-		EventHandlerType:              utils.LookupEnvOrString("HANDLER_TYPE", "libhoney"),
+		EventHandlerType:              utils.LookupEnvOrString("HANDLER_TYPE", "otel"),
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -116,6 +116,7 @@ func TestEnvVarsDefault(t *testing.T) {
 	assert.Equal(t, map[string]string{}, config.AdditionalAttributes)
 	assert.Equal(t, true, config.IncludeRequestURL)
 	assert.Equal(t, []string{"User-Agent", "Traceparent"}, config.HTTPHeadersToExtract)
+	assert.Equal(t, "otel", config.EventHandlerType)
 }
 
 func Test_Config_buildBpfFilter(t *testing.T) {

--- a/smoke-tests/deployment.yaml
+++ b/smoke-tests/deployment.yaml
@@ -147,8 +147,9 @@ spec:
             ## uncomment this to disable including the request URL in events
             # - name: INCLUDE_REQUEST_URL
             #   value: "false"
+            ## uncomment this to change the handler that is used to send events
             # - name: HANDLER_TYPE
-            #   value: "otel"
+            #   value: "libhoney"
           securityContext:
             capabilities:
               add:


### PR DESCRIPTION
## Which problem is this PR solving?
The agent currently defaults to using libhoney to send events. This PR updates the agent to default to OTel handler.

- Closes #305 

## Short description of the changes
- Update config default to `otel` instead of `libhoney`
- Updates smoke-test deployment's example headers to show how to use libhoney handler
- Add unit test to verify default config value

## How to verify that this has the expected result
The agent defaults to using OTel to send events