### PR TITLE
docs: update configs in readme and smoke-test deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,18 +54,18 @@ kubectl create secret generic honeycomb --from-literal=api-key=$HONEYCOMB_API_KE
 
 The network agent can be configured using the following environment variables.
 
-| Environment Variable      | Description                                                                              | Default                    | Required? |
-| ------------------------- | ---------------------------------------------------------------------------------------- | -------------------------- | --------- |
-| `HONEYCOMB_API_KEY`       | The Honeycomb API key used when sending events                                           | `` (empty)                 | **Yes**   |
-| `HONEYCOMB_API_ENDPOINT`  | The endpoint to send events to                                                           | `https://api.honeycomb.io` | No        |
-| `HONEYCOMB_DATASET`       | Dataset where network events are stored                                                  | `hny-network-agent`        | No        |
-| `HONEYCOMB_STATS_DATASET` | Dataset where operational statistics for the network agent are stored                    | `hny-network-agent-stats`  | No        |
-| `LOG_LEVEL`               | The log level to use when printing logs to console                                       | `INFO`                     | No        |
-| `DEBUG`                   | Runs the agent in debug mode including enabling a profiling endpoint using Debug Address | `false`                    | No        |
-| `DEBUG_ADDRESS`           | The endpoint to listen to when running the profile endpoint                              | `localhost:6060`           | No        |
-| `OTEL_RESOURCE_ATTRIBUTES`   | Extra attributes to include on all events                                                | `` (empty)                 | No        |
-| `INCLUDE_REQUEST_URL`     | Include the request URL in events                                                        | `true`                     | No        |
-| `HTTP_HEADERS`            | Case-sensitive, comma separated list of headers to be recorded from requests/responses†  | `User-Agent, Traceparent`  | No        |
+| Environment Variable       | Description                                                                              | Default                    | Required? |
+| -------------------------- | ---------------------------------------------------------------------------------------- | -------------------------- | --------- |
+| `HONEYCOMB_API_KEY`        | The Honeycomb API key used when sending events                                           | `` (empty)                 | **Yes**   |
+| `HONEYCOMB_API_ENDPOINT`   | The endpoint to send events to                                                           | `https://api.honeycomb.io` | No        |
+| `HONEYCOMB_DATASET`        | Dataset where network events are stored                                                  | `hny-network-agent`        | No        |
+| `HONEYCOMB_STATS_DATASET`  | Dataset where operational statistics for the network agent are stored                    | `hny-network-agent-stats`  | No        |
+| `LOG_LEVEL`                | The log level to use when printing logs to console                                       | `INFO`                     | No        |
+| `DEBUG`                    | Runs the agent in debug mode including enabling a profiling endpoint using Debug Address | `false`                    | No        |
+| `DEBUG_ADDRESS`            | The endpoint to listen to when running the profile endpoint                              | `localhost:6060`           | No        |
+| `OTEL_RESOURCE_ATTRIBUTES` | Extra attributes to include on all events                                                | `` (empty)                 | No        |
+| `INCLUDE_REQUEST_URL`      | Include the request URL in events                                                        | `true`                     | No        |
+| `HTTP_HEADERS`             | Case-sensitive, comma separated list of headers to be recorded from requests/responses†  | `User-Agent, Traceparent`  | No        |
 
 †: When providing an override of a list of values, you must include in your override any defaults you wish to keep.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The network agent can be configured using the following environment variables.
 | `LOG_LEVEL`               | The log level to use when printing logs to console                                       | `INFO`                     | No        |
 | `DEBUG`                   | Runs the agent in debug mode including enabling a profiling endpoint using Debug Address | `false`                    | No        |
 | `DEBUG_ADDRESS`           | The endpoint to listen to when running the profile endpoint                              | `localhost:6060`           | No        |
-| `ADDITIONAL_ATTRIBUTES`   | Extra attributes to include on all events                                                | `` (empty)                 | No        |
+| `OTEL_RESOURCE_ATTRIBUTES`   | Extra attributes to include on all events                                                | `` (empty)                 | No        |
 | `INCLUDE_REQUEST_URL`     | Include the request URL in events                                                        | `true`                     | No        |
 | `HTTP_HEADERS`            | Case-sensitive, comma separated list of headers to be recorded from requests/responses†  | `User-Agent, Traceparent`  | No        |
 

--- a/smoke-tests/deployment.yaml
+++ b/smoke-tests/deployment.yaml
@@ -143,7 +143,7 @@ spec:
             ## uncomment this to configure a list of HTTP headers to be recorded from requests/responses.
             ## this will show as http.request.header.user_agent and http.response.header.x_custom_header
             # - name: HTTP_HEADERS
-            #   value: "User-Agent,X-Custom-Header"
+            #   value: "User-Agent,Traceparent,X-Custom-Header"
             ## uncomment this to disable including the request URL in events
             # - name: INCLUDE_REQUEST_URL
             #   value: "false"


### PR DESCRIPTION
## Short description of the changes

- With OTel as default handler now, additional attributes should be defined in `OTEL_RESOURCE_ATTRIBUTES`
- Now that `Traceparent` is available and default, add to smoke test deployment for `HTTP_HEADERS`
