### PR TITLE
maint: Make smoke tests more reliable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ smokey_copy_output:
 		rm ./smoke-tests/traces-orig.json; \
 	fi
   # copy collector output file to local machine to run tests on
-  # the file may not be ready immediately, so retry a few times
+  # the file may not be ready immediately, so wait before trying to copy
   # note: the file is ignored in .gitignore
 	sleep 30
 	kubectl cp -c filecp default/smokey-collector-opentelemetry-collector-0:/tmp/trace.json ./smoke-tests/traces-orig.json; \

--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,11 @@ smokey_copy_output:
   # the file may not be ready immediately, so retry a few times
   # note: the file is ignored in .gitignore
 	for i in {1..10}; do \
+		sleep 10; \
 		kubectl cp -c filecp default/smokey-collector-opentelemetry-collector-0:/tmp/trace.json ./smoke-tests/traces-orig.json; \
 		if [ -f ./smoke-tests/traces-orig.json ]; then \
 			break; \
 		fi; \
-		sleep 5; \
 	done
 
 smokey_verify_output:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ smokey_agent_install: $(maybe_docker_build)
 	helm repo add honeycomb https://honeycombio.github.io/helm-charts
 	OTEL_COLLECTOR_IP="$(call get_collector_ip)" \
 		envsubst < smoke-tests/agent-helm-values.yaml | helm install smokey-agent honeycomb/network-agent --values -
-	kubectl rollout status daemonset.apps/smokey-agent-network-agent --timeout=10s
+	kubectl rollout status daemonset.apps/smokey-agent-network-agent --timeout=60s
 
 smokey_copy_output:
   # copy output from collector file to local machine
@@ -69,7 +69,7 @@ get_collector_ip = \
 smokey_echo_job:
 	make apply-echoserver
 	kubectl create --filename smoke-tests/smoke-job.yaml
-	kubectl rollout status deployment.apps/echoserver --timeout=10s --namespace echoserver
+	kubectl rollout status deployment.apps/echoserver --timeout=60s --namespace echoserver
 	kubectl wait --for=condition=complete job/smoke-job --timeout=60s --namespace echoserver
 
 .PHONY: unsmoke

--- a/Makefile
+++ b/Makefile
@@ -56,15 +56,11 @@ smokey_copy_output:
   # copy collector output file to local machine to run tests on
   # the file may not be ready immediately, so retry a few times
   # note: the file is ignored in .gitignore
-	for i in {1..10}; do \
-		echo "attempt $$i to get collector out file"; \
-		kubectl cp -c filecp default/smokey-collector-opentelemetry-collector-0:/tmp/trace.json ./smoke-tests/traces-orig.json; \
-		if [ -s ./smoke-tests/traces-orig.json ]; then \
-			echo "got collector out file"; \
-			break; \
-		fi; \
-		sleep 10; \
-	done
+	sleep 30
+	kubectl cp -c filecp default/smokey-collector-opentelemetry-collector-0:/tmp/trace.json ./smoke-tests/traces-orig.json; \
+	if [ ! -s ./smoke-tests/traces-orig.json ]; then \
+		echo "failed to copy collector output file"; \
+	fi;
 
 smokey_verify_output:
   # verify that the output from the collector matches the expected output

--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,13 @@ smokey_copy_output:
   # the file may not be ready immediately, so retry a few times
   # note: the file is ignored in .gitignore
 	for i in {1..10}; do \
-		sleep 10; \
+		echo "attempt $$i to get collector out file"; \
 		kubectl cp -c filecp default/smokey-collector-opentelemetry-collector-0:/tmp/trace.json ./smoke-tests/traces-orig.json; \
 		if [ -s ./smoke-tests/traces-orig.json ]; then \
+			echo "got collector out file"; \
 			break; \
 		fi; \
+		sleep 10; \
 	done
 
 smokey_verify_output:

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ smokey_copy_output:
 	for i in {1..10}; do \
 		sleep 10; \
 		kubectl cp -c filecp default/smokey-collector-opentelemetry-collector-0:/tmp/trace.json ./smoke-tests/traces-orig.json; \
-		if [ -f ./smoke-tests/traces-orig.json ]; then \
+		if [ -s ./smoke-tests/traces-orig.json ]; then \
 			break; \
 		fi; \
 	done

--- a/smoke-tests/echoserver.yaml
+++ b/smoke-tests/echoserver.yaml
@@ -9,7 +9,7 @@ metadata:
   name: echoserver
   namespace: echoserver
 spec:
-  replicas: 5
+  replicas: 1
   selector:
     matchLabels:
       app: echoserver


### PR DESCRIPTION
## Which problem is this PR solving?
Makes the smoke tests run more reliably. 

- Closes #320

## Short description of the changes
- Update rollout timeouts for network agent and echoserver to 60 seconds, they return as soon as they complete so it's okay to have a long timeout
- Decrease the number of echoserver replicas from 5 to 1, we don't need 5 and it increases the rollout time
- Update the `smokey_copy_output` makefile target to remove old version of the file if present and increase the wait time from 12 to 30 seconds

## How to verify that this has the expected result
The smoke tests run more reliably both in CI and locally.