### PR TITLE
rel: Prepare v0.1.0-beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Honeycomb Network Agent changelog
 
+## [0.1.0-beta] - 2023-12-01
+
+### Maintenance
+
+- maint: Add simple smoke test(s) (#310) | @RobbKidd
+- maint: Make smoke tests more reliable (#321) | @MikeGoldsmith
+
 ## [0.0.25-alpha] - 2023-11-22
 
 ### Fixes

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const Version string = "0.0.25-alpha"
+const Version string = "0.1.0-beta"
 
 func main() {
 	config := config.NewConfig()


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the first beta release.

## Short description of the changes
- update version to v0.1.0-beta
- add changelog entry

## How to verify that this has the expected result
The first beta release of the network agent can be published.