### PR TITLE
maint: add deps and docs to maintenance in release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -18,6 +18,8 @@ changelog:
     - title: 🛠 Maintenance
       labels:
         - "type: maintenance"
+        - "type: dependencies"
+        - "type: documentation"
     - title: 🤷 Other Changes
       labels:
         - "*"


### PR DESCRIPTION
## Which problem is this PR solving?

- we auto-generate release notes and if things aren't tagged they go into "other changes"

## Short description of the changes

- dependencies and documentation PRs are generally considered maintenance, so if it has that label, it should get auto-categorized as maintenance on the auto-generated release notes

