### PR TITLE
maint: update curl in smoke tests

### DIFF
--- a/smoke-tests/smoke-job.yaml
+++ b/smoke-tests/smoke-job.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: smoke-curl
-        image: docker.io/curlimages/curl
+        image: docker.io/curlimages/curl:8.5.0
         imagePullPolicy: IfNotPresent
         args:
         - --verbose

--- a/smoke-tests/verify.bats
+++ b/smoke-tests/verify.bats
@@ -21,7 +21,7 @@ SCOPE="hny-network-agent"
 
 @test "Agent includes specified headers as attributes" {
   result=$(span_attributes_for ${SCOPE} | jq "select(.key == \"http.request.header.user_agent\").value.stringValue")
-  assert_equal "$result" '"curl/8.4.0"'
+  assert_equal "$result" '"curl/8.5.0"'
 }
 
 @test "Agent includes k8s source attributes" {


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes failed test for updated curl image ([see failing test here](https://github.com/honeycombio/honeycomb-network-agent/actions/runs/7144635179/job/19458679899?pr=325))

## Short description of the changes

- specify tag in curl docker image
- update smoke test for curl version

## How to verify that this has the expected result

passing smoke tests