### PR TITLE
feat: add honeycomb resource attributes

### DIFF
--- a/handlers/libhoney_event_handler.go
+++ b/handlers/libhoney_event_handler.go
@@ -70,7 +70,6 @@ func initLibhoney(config config.Config, version string) func() {
 	// configure global fields that are set on all events
 	libhoney.AddField("honeycomb.agent.name", "Honeycomb Network Agent")
 	libhoney.AddField("honeycomb.agent.version", version)
-	libhoney.AddField("honeycomb.agent_version", version)
 
 	if config.AgentNodeIP != "" {
 		libhoney.AddField("meta.agent.node.ip", config.AgentNodeIP)

--- a/handlers/libhoney_event_handler.go
+++ b/handlers/libhoney_event_handler.go
@@ -68,6 +68,8 @@ func initLibhoney(config config.Config, version string) func() {
 	})
 
 	// configure global fields that are set on all events
+	libhoney.AddField("honeycomb.agent.name", "Honeycomb Network Agent")
+	libhoney.AddField("honeycomb.agent.version", version)
 	libhoney.AddField("honeycomb.agent_version", version)
 
 	if config.AgentNodeIP != "" {

--- a/handlers/otel_handler.go
+++ b/handlers/otel_handler.go
@@ -39,6 +39,8 @@ func NewOtelHandler(config config.Config, k8sClient *utils.CachedK8sClient, even
 			"x-honeycomb-team": config.APIKey,
 		}),
 		otelconfig.WithResourceAttributes(map[string]string{
+			"honeycomb.agent.name":           "Honeycomb Network Agent",
+			"honeycomb.agent.version":        version,
 			"honeycomb.agent_version":        version,
 			"meta.agent.node.ip":             config.AgentNodeIP,
 			"meta.agent.node.name":           config.AgentNodeName,

--- a/handlers/otel_handler.go
+++ b/handlers/otel_handler.go
@@ -41,7 +41,6 @@ func NewOtelHandler(config config.Config, k8sClient *utils.CachedK8sClient, even
 		otelconfig.WithResourceAttributes(map[string]string{
 			"honeycomb.agent.name":           "Honeycomb Network Agent",
 			"honeycomb.agent.version":        version,
-			"honeycomb.agent_version":        version,
 			"meta.agent.node.ip":             config.AgentNodeIP,
 			"meta.agent.node.name":           config.AgentNodeName,
 			"meta.agent.serviceaccount.name": config.AgentServiceAccount,

--- a/smoke-tests/verify.bats
+++ b/smoke-tests/verify.bats
@@ -14,6 +14,11 @@ SCOPE="hny-network-agent"
   assert_equal "$result" '"smokey"'
 }
 
+@test "Agent includes Honeycomb resource attributes" {
+  result=$(resource_attributes_received | jq "select(.key == \"honeycomb.agent.name\").value.stringValue")
+  assert_equal "$result" '"Honeycomb Network Agent"'
+}
+
 @test "Agent emits a span name '{http.method}' (per semconv)" {
   result=$(span_names_for ${SCOPE})
   assert_equal "$result" '"POST"'

--- a/smoke-tests/verify.bats
+++ b/smoke-tests/verify.bats
@@ -14,9 +14,12 @@ SCOPE="hny-network-agent"
   assert_equal "$result" '"smokey"'
 }
 
-@test "Agent includes Honeycomb resource attributes" {
+@test "Agent includes Honeycomb agent resource attributes" {
   result=$(resource_attributes_received | jq "select(.key == \"honeycomb.agent.name\").value.stringValue")
   assert_equal "$result" '"Honeycomb Network Agent"'
+
+  version=$(resource_attributes_received | jq "select(.key == \"honeycomb.agent.version\").value.stringValue")
+  assert_not_empty "$version"
 }
 
 @test "Agent emits a span name '{http.method}' (per semconv)" {


### PR DESCRIPTION
## Which problem is this PR solving?

- Updates #328 

## Short description of the changes

- Add `honeycomb.agent.name` and `honeycomb.agent.version` as resource attributes to help distinguish where telemetry came from. This is similar to the `honeycomb.distro.*` attributes in our distros, and `telemetry.sdk.*` attributes from otel.
- Update smoke test to check for presence of the name

## How to verify that this has the expected result

Telemetry should include those fields, with no other changes