### PR TITLE
rel: Prepare the v0.2.0-beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Honeycomb Network Agent changelog
 
+## [0.2.0-beta] - 2023-12-14
+
+💥 Breaking changes 💥
+
+This release replaces the resource attribute `honeycomb.agent_version` with `honeycomb.agent.version`.
+If you're using that attribute to identify traffic that's coming from the Network Agent, you will need to update to use the new name.
+
+### Enhancements
+
+- feat: add honeycomb resource attributes (#331) | Jamie Danielson
+
+### Maintenance
+
+- maint: add deps and docs to maintenance in release (#326) | Jamie Danielson
+- maint: update codeowners to pipeline-team (#330) | Jamie Danielson
+- maint: update codeowners to pipeline (#325) | Jamie Danielson
+- maint: update curl in smoke tests (#327) | Jamie Danielson
+- maint(deps): bump github.com/honeycombio/otel-config-go from 1.13.0 to 1.13.1 (#329) | @Dependabot
+
 ## [0.1.0-beta] - 2023-12-01
 
 ### Maintenance

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const Version string = "0.1.0-beta"
+const Version string = "0.2.0-beta"
 
 func main() {
 	config := config.NewConfig()


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the next release of the network agent.

## Short description of the changes
- Upadate version to v0.2.0-beta
- Add changelog entry

## How to verify that this has the expected result
The next release of the agent can be published. 