### PR TITLE
rel: Prepare v0.2.1-beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Honeycomb Network Agent changelog
 
+## [0.2.1-beta] - 2024-02-06
+
+### Maintenance
+
+- maint: bump dependencies (#337) | @TylerHelmuth
+- maint(deps): bump github.com/rs/zerolog from 1.31.0 to 1.32.0 (#338) | @Dependabot
+- maint(deps): bump the k8s-dependencies group with 2 updates (#333) | @Dependabot
+
 ## [0.2.0-beta] - 2023-12-14
 
 💥 Breaking changes 💥

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const Version string = "0.2.0-beta"
+const Version string = "0.2.1-beta"
 
 func main() {
 	config := config.NewConfig()


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the next release of the Network Agent.

## Short description of the changes
- Updates version to 0.2.1-beta in main.go
- Adds changelog entry

## How to verify that this has the expected result
The new version can be tagged and published.