### PR TITLE
chore: Update dependabot reviewers and schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,9 @@ updates:
     labels:
       - "type: dependencies"
     reviewers:
-      - "honeycombio/telemetry-team"
+      - "honeycombio/pipeline-team"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "maint"
       include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

Updates dependabot config reviewers and schdedule.

## Short description of the changes
- Update reviewers to @honeycombio/pipeline-team 
- Update schedule to monthly